### PR TITLE
Add Generated NOT for auto generated codes

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
@@ -4019,7 +4019,7 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	protected InboundEndpointImpl() {
 		super();
@@ -9672,7 +9672,7 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated
+	 * @generated NOT
 	 */
 	@Override
 	public String toString() {


### PR DESCRIPTION
This is added to fix the issue of regenerating the InboundEndpointImpl.java source (which should not regenerate) when generating the gmf gen model.
This fix is related to the commit ae3176df43a7cb0d2c13304cade1c005815436b4