### PR TITLE
[ESB_TOOL-30]Fix for namespace issue with builder mediator

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/configure/ui/MessageBuilderPropertyDialog.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/configure/ui/MessageBuilderPropertyDialog.java
@@ -199,6 +199,9 @@ public class MessageBuilderPropertyDialog extends Dialog {
 
 		MessageBuilder messageBuilder = EsbFactory.eINSTANCE
 				.createMessageBuilder();
+		messageBuilder.setContentType(cTypeTxt.getText());
+		messageBuilder.setBuilderClass(builderClassTxt.getText());
+		messageBuilder.setFormatterClass(formatterClassTxt.getText());
 		TableItem item = bindBuilder(messageBuilder);
 
 		AddCommand addCmd = new AddCommand(editingDomain, builderMediator,

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/custom/BuilderMediatorExtSerializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/custom/BuilderMediatorExtSerializer.java
@@ -3,6 +3,7 @@ package org.wso2.developerstudio.eclipse.gmf.esb.internal.persistence.custom;
 import java.util.List;
 
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNamespace;
 import org.apache.synapse.Mediator;
 import org.apache.synapse.config.xml.AbstractMediatorSerializer;
 import org.wso2.developerstudio.eclipse.gmf.esb.MessageBuilder;
@@ -18,7 +19,8 @@ public class BuilderMediatorExtSerializer extends AbstractMediatorSerializer {
 		}
 
 		BuilderMediatorExt builderMediatorExt = (BuilderMediatorExt) mediator;
-		OMElement builder = fac.createOMElement("builder", nullNS);
+		OMNamespace namespace = fac.createOMNamespace("http://ws.apache.org/ns/synapse", "syn");
+		OMElement builder = fac.createOMElement("builder", namespace);
 		saveTracingState(builder, mediator);
 
 		List<MessageBuilder> messageBuilderList = builderMediatorExt
@@ -29,7 +31,7 @@ public class BuilderMediatorExtSerializer extends AbstractMediatorSerializer {
 			for (MessageBuilder messageBuilder : messageBuilderList) {
 
 				OMElement omMessageBuilder = fac.createOMElement(
-						"messageBuilder", nullNS);
+						"messageBuilder", namespace);
 
 				if (messageBuilder.getContentType() != null) {
 


### PR DESCRIPTION
Fix for the syntax error caused with null namespace in builder mediator [1]. 
[1] - https://github.com/wso2/devstudio-tooling-ei/issues/30