### PR TITLE
Fix the issue of not supporting '\t' as log separators

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/LogMediatorDeserializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/LogMediatorDeserializer.java
@@ -109,10 +109,11 @@ public class LogMediatorDeserializer extends AbstractEsbNodeDeserializer<Abstrac
 		}
 		
 		
-		if (!StringUtils.isBlank(logMediator.getSeparator())) {
+		if (!logMediator.getSeparator().isEmpty()) {
 			
 			//visualLog.setLogSeparator(logMediator.getSeparator());
-			executeSetValueCommand(LOG_MEDIATOR__LOG_SEPARATOR, logMediator.getSeparator());
+			executeSetValueCommand(LOG_MEDIATOR__LOG_SEPARATOR,
+					logMediator.getSeparator().replace("\n", "\\n").replace("\t", "\\t"));
 		}
 		
 		


### PR DESCRIPTION
Fix the issue of not supporting '\t' as log separators in Log mediators in dev studio.
Resolves : https://wso2.org/jira/browse/DEVTOOLEI-1124