### PR TITLE
[EI-TOOL-74] Fix for Log Separator in Log mediator

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/LogMediatorDeserializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/LogMediatorDeserializer.java
@@ -109,10 +109,10 @@ public class LogMediatorDeserializer extends AbstractEsbNodeDeserializer<Abstrac
 		}
 		
 		
-		if (!StringUtils.isBlank(logMediator.getSeparator())) {
+		if (!logMediator.getSeparator().isEmpty()) {
 			
 			//visualLog.setLogSeparator(logMediator.getSeparator());
-			executeSetValueCommand(LOG_MEDIATOR__LOG_SEPARATOR, logMediator.getSeparator());
+			executeSetValueCommand(LOG_MEDIATOR__LOG_SEPARATOR, logMediator.getSeparator().replace("\n", "\\n").replace("\t", "\\t"));
 		}
 		
 		


### PR DESCRIPTION
Fixed the issue of not converting log separator charachter '\t' into
relevant encoded charachters in the source view, when adding it from the design view
Related Issue : https://github.com/wso2/devstudio-tooling-ei/issues/74