### PR TITLE
[EI_TOOL-75] Fix for file handle leak issue

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode2EditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode2EditPart.java
@@ -50,6 +50,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.graphics.Font;
+import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.wso2.developerstudio.datamapper.PropertyKeyValuePair;
@@ -96,6 +97,72 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 	private static final String JSON_SCHEMA_OBJECT_VALUE_TYPE = "object_value_type";
 	private static final String JSON_SCHEMA_ARRAY_ITEMS_TYPE = "items_type";
 	private static final String NULL_VALUE = "null";
+
+	private static final String CREATE_DATA_MAPPER_LINK1_CREATION_TOOL = "createDataMapperLink1CreationTool";
+	private static final String ELEMENT_ICON = "icons/gmf/element.png";
+	private static final String ATTRIBUTE_ICON = "icons/gmf/attribute.png";
+	private static final String ARRAY_ICON = "icons/gmf/array.png";
+	private static final String OBJECT_ICON = "icons/gmf/object.png";
+	private static final String NULLABLE_ELEMENT_ICON = "icons/gmf/element-null.png";
+	private static final String NULLABLE_ATTRIBUTE_ICON = "icons/gmf/attribute-null.png";
+	private static final String NULLABLE_ARRAY_ICON = "icons/gmf/array-null.png";
+	private static final String NULLABLE_OBJECT_ICON = "icons/gmf/object-null.png";
+	private static final String ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM = "org.wso2.developerstudio.visualdatamapper.diagram";
+	private static final String TRUE = "true";
+	private static final String FALSE = "false";
+	private static final String JSON_SCHEMA_NULLABLE = "nullable";
+
+	private static final String PREFIX = "@";
+	private static final String SCHEMA_TYPE_PREFIX = "  :[";
+	private static final String SCHEMA_TYPE_POSTFIX = "]";
+
+	static ImageDescriptor elementImgDescCollapse;
+	static ImageDescriptor attributeImgDesc;
+	static ImageDescriptor arrayImgDesc;
+	static ImageDescriptor objectImgDesc;
+	static ImageDescriptor nullableElementImgDesc;
+	static ImageDescriptor nullableAttributeImgDesc;
+	static ImageDescriptor nullableObjectImgDesc;
+	static ImageDescriptor nullableArrayImgDesc;
+	static Image elementImage;
+	static Image attributeImage;
+	static Image arrayImage;
+	static Image objectImage;
+	static Image nullableElementImage;
+	static Image nullableAttributeImage;
+	static Image nullableArrayImage;
+	static Image nullableObjectImage;
+	static {
+	    elementImgDescCollapse = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ELEMENT_ICON);
+
+	    attributeImgDesc = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ATTRIBUTE_ICON);
+
+	    arrayImgDesc = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ARRAY_ICON);
+
+	    objectImgDesc = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, OBJECT_ICON);
+
+	    nullableElementImgDesc = AbstractUIPlugin.imageDescriptorFromPlugin(
+				ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ELEMENT_ICON);
+	    nullableAttributeImgDesc = AbstractUIPlugin.imageDescriptorFromPlugin(
+				ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ATTRIBUTE_ICON);
+	    nullableArrayImgDesc = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ARRAY_ICON);
+	    nullableObjectImgDesc = AbstractUIPlugin
+				.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_OBJECT_ICON);
+
+	    elementImage = elementImgDescCollapse.createImage();
+	    attributeImage = attributeImgDesc.createImage();
+	    arrayImage = arrayImgDesc.createImage();
+	    objectImage = objectImgDesc.createImage();
+	    nullableElementImage = nullableElementImgDesc.createImage();
+	    nullableAttributeImage = nullableAttributeImgDesc.createImage();
+	    nullableArrayImage = nullableArrayImgDesc.createImage();
+	    nullableObjectImage = nullableObjectImgDesc.createImage();
+	}
 
 	/**
 	 * @generated
@@ -683,26 +750,6 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 	 */
 	public class TreeNodeFigure extends RectangleFigure {
 
-		private static final String CREATE_DATA_MAPPER_LINK1_CREATION_TOOL = "createDataMapperLink1CreationTool";
-		private static final String ELEMENT_ICON = "icons/gmf/element.png";
-		private static final String ATTRIBUTE_ICON = "icons/gmf/attribute.png";
-		private static final String ARRAY_ICON = "icons/gmf/array.png";
-		private static final String OBJECT_ICON = "icons/gmf/object.png";
-		private static final String NULLABLE_ELEMENT_ICON = "icons/gmf/element-null.png";
-		private static final String NULLABLE_ATTRIBUTE_ICON = "icons/gmf/attribute-null.png";
-		private static final String NULLABLE_ARRAY_ICON = "icons/gmf/array-null.png";
-		private static final String NULLABLE_OBJECT_ICON = "icons/gmf/object-null.png";
-		private static final String ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM = "org.wso2.developerstudio.visualdatamapper.diagram";
-		private static final String JSON_SCHEMA_TYPE = "type";
-		private static final String JSON_SCHEMA_ARRAY = "array";
-		private static final String JSON_SCHEMA_OBJECT = "object";
-		private static final String TRUE = "true";
-		private static final String FALSE = "false";
-		private static final String JSON_SCHEMA_NULLABLE = "nullable";
-
-		private static final String PREFIX = "@";
-		private static final String SCHEMA_TYPE_PREFIX = "  :[";
-		private static final String SCHEMA_TYPE_POSTFIX = "]";
 		/**
 		 * @generated
 		 */
@@ -754,58 +801,28 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 			figure2.setBorder(null);
 			figure2.setOpaque(false);
 
-			ImageDescriptor elementImgDescCollapse = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ELEMENT_ICON);// plus
-
-			ImageDescriptor attributeImgDesc = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ATTRIBUTE_ICON);
-
-			ImageDescriptor arrayImgDesc = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, ARRAY_ICON);
-
-			ImageDescriptor objectImgDesc = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, OBJECT_ICON);
-
-			ImageDescriptor nullableElementImgDesc = AbstractUIPlugin.imageDescriptorFromPlugin(
-					ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ELEMENT_ICON);
-			ImageDescriptor nullableAttributeImgDesc = AbstractUIPlugin.imageDescriptorFromPlugin(
-					ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ATTRIBUTE_ICON);
-			ImageDescriptor nullableObjectImgDesc = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_OBJECT_ICON);
-			ImageDescriptor nullableArrayImgDesc = AbstractUIPlugin
-					.imageDescriptorFromPlugin(ORG_WSO2_DEVELOPERSTUDIO_VISUALDATAMAPPER_DIAGRAM, NULLABLE_ARRAY_ICON);
-
-			final ImageFigure mainImg = new ImageFigure(elementImgDescCollapse.createImage());
+			final ImageFigure mainImg = new ImageFigure(elementImage);
 			mainImg.setSize(new Dimension(10, 8));
-			ImageFigure attributeImg = new ImageFigure(attributeImgDesc.createImage()); // attribute
-																						// symbole
-																						// figure
+
+			ImageFigure attributeImg = new ImageFigure(attributeImage);
 			attributeImg.setSize(new Dimension(10, 8));
-			ImageFigure arrayImg = new ImageFigure(arrayImgDesc.createImage()); // array
-																				// symbole
-																				// figure
+
+			ImageFigure arrayImg = new ImageFigure(arrayImage);
 			arrayImg.setSize(new Dimension(10, 8));
-			ImageFigure objectImg = new ImageFigure(objectImgDesc.createImage()); // object
-																					// symbole
-																					// figure
+
+			ImageFigure objectImg = new ImageFigure(objectImage);
 			objectImg.setSize(new Dimension(10, 8));
 
-			ImageFigure nullableObjectImg = new ImageFigure(nullableObjectImgDesc.createImage()); // object
-			// symbole
-			// figure
+			ImageFigure nullableObjectImg = new ImageFigure(nullableObjectImage);
 			nullableObjectImg.setSize(new Dimension(10, 8));
 
-			ImageFigure nullableArrayImg = new ImageFigure(nullableArrayImgDesc.createImage()); // object
-			// symbole
-			// figure
+			ImageFigure nullableArrayImg = new ImageFigure(nullableArrayImage);
 			nullableArrayImg.setSize(new Dimension(10, 8));
-			ImageFigure nullableAttributeImg = new ImageFigure(nullableAttributeImgDesc.createImage()); // object
-			// symbole
-			// figure
+
+			ImageFigure nullableAttributeImg = new ImageFigure(nullableAttributeImage);
 			nullableAttributeImg.setSize(new Dimension(10, 8));
-			ImageFigure nullableElementImg = new ImageFigure(nullableElementImgDesc.createImage()); // object
-			// symbole
-			// figure
+
+			ImageFigure nullableElementImg = new ImageFigure(nullableElementImage);
 			nullableElementImg.setSize(new Dimension(10, 8));
 
 			RectangleFigure mainImageRectangle = new RectangleFigure();


### PR DESCRIPTION
Fixed: https://github.com/wso2/devstudio-tooling-ei/issues/75

The issue tried to address here was to properly dispose the resources created at data mapper tree nodes generation. Since there was no methods to identify the completion of image draw event, we used static images and ImageDescriptors to avoid generating multiple copies of same resource.