### PR TITLE
Fix devstudio-tooling-ei/issues/110.

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/InboundEndpointDeserializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/InboundEndpointDeserializer.java
@@ -41,6 +41,8 @@ import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOU
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_SESSION_ACKNOWLEDGEMENT;
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_SESSION_TRANSACTED;
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_SHARED_SUBSCRIPTION;
+import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION;
+import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD;
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_QOS;
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_VFS_ACTION_AFTER_FAILURE;
 import static org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_VFS_ACTION_AFTER_PROCESS;
@@ -483,6 +485,12 @@ public class InboundEndpointDeserializer extends
                         } else {
                             executeSetValueCommand(INBOUND_ENDPOINT__TRANSPORT_JMS_SHARED_SUBSCRIPTION, false);
                         }
+                    } else if (paramEntry.getKey().equals(InboundEndpointConstants.JMS_RETRIES_BEFORE_SUSPENSION)) {
+                        executeSetValueCommand(INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION,
+                                paramEntry.getValue());
+                    } else if (paramEntry.getKey().equals(InboundEndpointConstants.JMS_POLLING_SUSPENSION_PERIOD)) {
+                        executeSetValueCommand(INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD,
+                                paramEntry.getValue());
                     }
                 }
             }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
@@ -2379,3 +2379,5 @@ _UI_MessageStore_resequencePassword_feature = Resequence Password
 _UI_MessageStore_resequenceDatasourceName_feature = Resequence Datasource Name
 _UI_MessageStore_resequenceXpath_feature = Resequence Xpath
 _UI_MessageStore_resequenceXpathAttr_feature = Resequence Xpath Attr
+_UI_InboundEndpoint_transportJmsRetriesBeforeSuspension_feature = Transport Jms Retries Before Suspension
+_UI_InboundEndpoint_transportJmsPollingSuspensionPeriod_feature = Transport Jms Polling Suspension Period

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/InboundEndpointItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/InboundEndpointItemProvider.java
@@ -137,6 +137,8 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 			addTransportJMSPinnedServersPropertyDescriptor(object);
 			addTransportJMSConcurrentConsumersPropertyDescriptor(object);
 			addTransportJMSRetryDurationPropertyDescriptor(object);
+			addTransportJmsRetriesBeforeSuspensionPropertyDescriptor(object);
+			addTransportJmsPollingSuspensionPeriodPropertyDescriptor(object);
 			break;
 		case CUSTOM:
 			addClassPropertyDescriptor(object);
@@ -2514,6 +2516,50 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 	}
 
 	/**
+	 * This adds a property descriptor for the Transport Jms Retries Before Suspension feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	protected void addTransportJmsRetriesBeforeSuspensionPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_InboundEndpoint_transportJmsRetriesBeforeSuspension_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJmsRetriesBeforeSuspension_feature", "_UI_InboundEndpoint_type"),
+				 EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 "Parameters",
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Transport Jms Polling Suspension Period feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	protected void addTransportJmsPollingSuspensionPeriodPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_InboundEndpoint_transportJmsPollingSuspensionPeriod_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJmsPollingSuspensionPeriod_feature", "_UI_InboundEndpoint_type"),
+				 EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 "Parameters",
+				 null));
+	}
+
+	/**
 	 * This adds a property descriptor for the Class feature. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
 	 * 
@@ -4336,6 +4382,8 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_FEED_TYPE:
 			case EsbPackage.INBOUND_ENDPOINT__TRACE_ENABLED:
 			case EsbPackage.INBOUND_ENDPOINT__STATISTICS_ENABLED:
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION:
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));
 				return;
 			case EsbPackage.INBOUND_ENDPOINT__SEQUENCE_INPUT_CONNECTOR:

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/InboundEndpointTransformer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/InboundEndpointTransformer.java
@@ -436,6 +436,14 @@ public class InboundEndpointTransformer extends AbstractEsbNodeTransformer {
 				addParameterForConfig(inboundEndpoint, InboundEndpointConstants.JMS_RETRY_DURATION,
 						visualInboundEndpoint.getTransportJMSRetryDuration());
 			}
+            if (StringUtils.isNotBlank(visualInboundEndpoint.getTransportJmsRetriesBeforeSuspension())) {
+                addParameterForConfig(inboundEndpoint, InboundEndpointConstants.JMS_RETRIES_BEFORE_SUSPENSION,
+                        visualInboundEndpoint.getTransportJmsRetriesBeforeSuspension());
+            }
+            if (StringUtils.isNotBlank(visualInboundEndpoint.getTransportJmsPollingSuspensionPeriod())) {
+                addParameterForConfig(inboundEndpoint, InboundEndpointConstants.JMS_POLLING_SUSPENSION_PERIOD,
+                        visualInboundEndpoint.getTransportJmsPollingSuspensionPeriod());
+            }
             
             break;
         case WSO2_MB:

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/persistence/InboundEndpointConstants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/persistence/InboundEndpointConstants.java
@@ -98,6 +98,8 @@ public class InboundEndpointConstants {
 	public static final String JMS_SUBSCRIPTION_NAME = "transport.jms.SubscriptionName";
 	public static final String JMS_CONCURRENT_CONSUMERS = "concurrent.consumers";
 	public static final String JMS_RETRY_DURATION = "transport.jms.retry.duration";
+	public static final String JMS_RETRIES_BEFORE_SUSPENSION = "transport.jms.RetriesBeforeSuspension";
+	public static final String JMS_POLLING_SUSPENSION_PERIOD = "transport.jms.PollingSuspensionPeriod";
 
 	public static final String WSO2_MB_CONNECTION_URL ="wso2mb.connection.url";
 	public static final String WSO2_MB__QUEUE_CONNECTION_URL ="connectionfactory.QueueConnectionFactory";

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
@@ -1415,7 +1415,8 @@
         defaultValueLiteral="120"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="maxMessageSize" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
         defaultValueLiteral="2000"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="cacheProtocolMethods" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="cacheProtocolMethods" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        defaultValueLiteral="*"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="maxEntryCount" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EInt"
         defaultValueLiteral="1000"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="sequenceType" eType="#//CacheSequenceType"
@@ -1432,7 +1433,8 @@
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="headersToExcludeInHash"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="responseCodes" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="responseCodes" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
+        defaultValueLiteral=".*"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="CacheMediatorInputConnector" eSuperTypes="#//InputConnector"/>
   <eClassifiers xsi:type="ecore:EClass" name="CacheMediatorOutputConnector" eSuperTypes="#//OutputConnector"/>
@@ -3201,6 +3203,10 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportFeedType" eType="#//FeedType"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="traceEnabled" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="statisticsEnabled" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJmsRetriesBeforeSuspension"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJmsPollingSuspensionPeriod"
+        eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="InboundEndpointParameter">
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.genmodel
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.genmodel
@@ -201,6 +201,24 @@
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/TRANSPORT_IN_NAME"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/To"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/transportNonBlocking"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/JMS_CONNECTION_FACTORY"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/JMS_DESTINATION"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/JMS_DESTINATION_TYPE"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/JMS_REPLY_DESTINATION"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/JMS_WRAPPER"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_FILE_URI"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_CONTENT_TYPE"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_FILENAME_PATTERN"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/POLL_INTERVAL"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_ACTION_AFTER_PROCESS"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_MOVE_AFTER_PROCESS"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_ACTION_AFTER_ERRORS"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_MOVE_AFTER_ERRORS"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_ACTION_AFTER_FAILURE"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_MOVE_AFTER_FAILURE"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_REPLY_FILE_URI"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_REPLY_FILENAME"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//PropertyName/VFS_MOVE_TIMESTAMP_FORMAT"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//EnrichSourceInlineType">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichSourceInlineType/CONTENT"/>
@@ -220,9 +238,9 @@
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//EnrichTargetType">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichTargetType/CUSTOM"/>
-      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichTargetType/ENVELOPE"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichTargetType/BODY"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichTargetType/PROPERTY"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnrichTargetType/ENVELOPE"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//EventTopicType">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EventTopicType/STATIC"/>
@@ -257,6 +275,7 @@
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//ScriptLanguage/JAVASCRIPT"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//ScriptLanguage/RUBY"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//ScriptLanguage/GROOVY"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//ScriptLanguage/NASHORNJS"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//FaultSoapVersion">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//FaultSoapVersion/SOAP_1_1"/>
@@ -314,16 +333,12 @@
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheSequenceType/ANONYMOUS"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheSequenceType/REGISTRY_REFERENCE"/>
     </genEnums>
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//CacheImplementationType">
-      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheImplementationType/IN_MEMORY"/>
-    </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//CacheAction">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheAction/FINDER"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheAction/COLLECTOR"/>
     </genEnums>
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//CacheScope">
-      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheScope/PER_MEDIATOR"/>
-      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheScope/PER_HOST"/>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//CacheProtocolType">
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//CacheProtocolType/HTTP"/>
     </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//XQueryVariableType">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//XQueryVariableType/DOCUMENT"/>
@@ -742,9 +757,6 @@
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//EnableDisableState">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnableDisableState/Disabled"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//EnableDisableState/Enabled"/>
-    </genEnums>
-    <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//HashGenerator">
-      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//HashGenerator/CARBON_MEDIATOR_CACHE_DIGEST_DOMHASH_GENERATOR"/>
     </genEnums>
     <genDataTypes ecoreDataType="esb.ecore#//Map">
       <genTypeParameters ecoreTypeParameter="esb.ecore#//Map/K"/>
@@ -1494,12 +1506,12 @@
     </genClasses>
     <genClasses ecoreClass="esb.ecore#//CacheMediator">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheId"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheScope"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheProtocolType"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheAction"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/hashGenerator"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheTimeout"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/maxMessageSize"/>
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/implementationType"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/cacheProtocolMethods"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/maxEntryCount"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/sequenceType"/>
       <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference esb.ecore#//CacheMediator/sequenceKey"/>
@@ -1507,6 +1519,8 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference esb.ecore#//CacheMediator/outputConnector"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference esb.ecore#//CacheMediator/onHitOutputConnector"/>
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference esb.ecore#//CacheMediator/mediatorFlow"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/headersToExcludeInHash"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//CacheMediator/responseCodes"/>
     </genClasses>
     <genClasses ecoreClass="esb.ecore#//CacheMediatorInputConnector"/>
     <genClasses ecoreClass="esb.ecore#//CacheMediatorOutputConnector"/>
@@ -2508,6 +2522,8 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportFeedType"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/traceEnabled"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/statisticsEnabled"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJmsRetriesBeforeSuspension"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJmsPollingSuspensionPeriod"/>
     </genClasses>
     <genClasses ecoreClass="esb.ecore#//InboundEndpointParameter">
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpointParameter/name"/>

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
@@ -24797,13 +24797,31 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	int INBOUND_ENDPOINT__STATISTICS_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 186;
 
 	/**
+	 * The feature id for the '<em><b>Transport Jms Retries Before Suspension</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION = ESB_ELEMENT_FEATURE_COUNT + 187;
+
+	/**
+	 * The feature id for the '<em><b>Transport Jms Polling Suspension Period</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD = ESB_ELEMENT_FEATURE_COUNT + 188;
+
+	/**
 	 * The number of structural features of the '<em>Inbound Endpoint</em>' class.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 187;
+	int INBOUND_ENDPOINT_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 189;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointParameterImpl <em>Inbound Endpoint Parameter</em>}' class.
@@ -35255,6 +35273,28 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 */
 	EAttribute getInboundEndpoint_StatisticsEnabled();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsRetriesBeforeSuspension <em>Transport Jms Retries Before Suspension</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Transport Jms Retries Before Suspension</em>'.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsRetriesBeforeSuspension()
+	 * @see #getInboundEndpoint()
+	 * @generated
+	 */
+	EAttribute getInboundEndpoint_TransportJmsRetriesBeforeSuspension();
+
+	/**
+	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsPollingSuspensionPeriod <em>Transport Jms Polling Suspension Period</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Transport Jms Polling Suspension Period</em>'.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsPollingSuspensionPeriod()
+	 * @see #getInboundEndpoint()
+	 * @generated
+	 */
+	EAttribute getInboundEndpoint_TransportJmsPollingSuspensionPeriod();
 
 	/**
 	 * Returns the meta object for class '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpointParameter <em>Inbound Endpoint Parameter</em>}'.
@@ -50994,6 +51034,22 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 		 * @generated
 		 */
 		EAttribute INBOUND_ENDPOINT__STATISTICS_ENABLED = eINSTANCE.getInboundEndpoint_StatisticsEnabled();
+
+		/**
+		 * The meta object literal for the '<em><b>Transport Jms Retries Before Suspension</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION = eINSTANCE.getInboundEndpoint_TransportJmsRetriesBeforeSuspension();
+
+		/**
+		 * The meta object literal for the '<em><b>Transport Jms Polling Suspension Period</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD = eINSTANCE.getInboundEndpoint_TransportJmsPollingSuspensionPeriod();
 
 		/**
 		 * The meta object literal for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointParameterImpl <em>Inbound Endpoint Parameter</em>}' class.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/InboundEndpoint.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/InboundEndpoint.java
@@ -214,6 +214,8 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportFeedType <em>Transport Feed Type</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#isTraceEnabled <em>Trace Enabled</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#isStatisticsEnabled <em>Statistics Enabled</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsRetriesBeforeSuspension <em>Transport Jms Retries Before Suspension</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsPollingSuspensionPeriod <em>Transport Jms Polling Suspension Period</em>}</li>
  * </ul>
  *
  * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getInboundEndpoint()
@@ -2975,6 +2977,58 @@ public interface InboundEndpoint extends EsbElement {
 	 * @generated
 	 */
 	void setStatisticsEnabled(boolean value);
+
+	/**
+	 * Returns the value of the '<em><b>Transport Jms Retries Before Suspension</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Transport Jms Retries Before Suspension</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Transport Jms Retries Before Suspension</em>' attribute.
+	 * @see #setTransportJmsRetriesBeforeSuspension(String)
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getInboundEndpoint_TransportJmsRetriesBeforeSuspension()
+	 * @model
+	 * @generated
+	 */
+	String getTransportJmsRetriesBeforeSuspension();
+
+	/**
+	 * Sets the value of the '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsRetriesBeforeSuspension <em>Transport Jms Retries Before Suspension</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Transport Jms Retries Before Suspension</em>' attribute.
+	 * @see #getTransportJmsRetriesBeforeSuspension()
+	 * @generated
+	 */
+	void setTransportJmsRetriesBeforeSuspension(String value);
+
+	/**
+	 * Returns the value of the '<em><b>Transport Jms Polling Suspension Period</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Transport Jms Polling Suspension Period</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Transport Jms Polling Suspension Period</em>' attribute.
+	 * @see #setTransportJmsPollingSuspensionPeriod(String)
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getInboundEndpoint_TransportJmsPollingSuspensionPeriod()
+	 * @model
+	 * @generated
+	 */
+	String getTransportJmsPollingSuspensionPeriod();
+
+	/**
+	 * Sets the value of the '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJmsPollingSuspensionPeriod <em>Transport Jms Polling Suspension Period</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Transport Jms Polling Suspension Period</em>' attribute.
+	 * @see #getTransportJmsPollingSuspensionPeriod()
+	 * @generated
+	 */
+	void setTransportJmsPollingSuspensionPeriod(String value);
 
 	/**
 	 * Returns the value of the '<em><b>Class</b></em>' attribute.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
@@ -11434,6 +11434,24 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getInboundEndpoint_TransportJmsRetriesBeforeSuspension() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(187);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TransportJmsPollingSuspensionPeriod() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(188);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EClass getInboundEndpointParameter() {
 		return inboundEndpointParameterEClass;
 	}
@@ -20709,6 +20727,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_FEED_TYPE);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRACE_ENABLED);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__STATISTICS_ENABLED);
+		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION);
+		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD);
 
 		inboundEndpointParameterEClass = createEClass(INBOUND_ENDPOINT_PARAMETER);
 		createEAttribute(inboundEndpointParameterEClass, INBOUND_ENDPOINT_PARAMETER__NAME);
@@ -23106,6 +23126,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		initEAttribute(getInboundEndpoint_TransportFeedType(), this.getFeedType(), "transportFeedType", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TraceEnabled(), ecorePackage.getEBoolean(), "traceEnabled", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_StatisticsEnabled(), ecorePackage.getEBoolean(), "statisticsEnabled", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getInboundEndpoint_TransportJmsRetriesBeforeSuspension(), ecorePackage.getEString(), "transportJmsRetriesBeforeSuspension", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getInboundEndpoint_TransportJmsPollingSuspensionPeriod(), ecorePackage.getEString(), "transportJmsPollingSuspensionPeriod", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(inboundEndpointParameterEClass, InboundEndpointParameter.class, "InboundEndpointParameter", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
 		initEAttribute(getInboundEndpointParameter_Name(), ecorePackage.getEString(), "name", "parameter_name", 0, 1, InboundEndpointParameter.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
@@ -250,6 +250,8 @@ import org.wso2.developerstudio.eclipse.gmf.esb.WSClientSideBroadcastLevel;
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportFeedType <em>Transport Feed Type</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#isTraceEnabled <em>Trace Enabled</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#isStatisticsEnabled <em>Statistics Enabled</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJmsRetriesBeforeSuspension <em>Transport Jms Retries Before Suspension</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJmsPollingSuspensionPeriod <em>Transport Jms Polling Suspension Period</em>}</li>
  * </ul>
  *
  * @generated
@@ -4018,6 +4020,46 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 	protected boolean statisticsEnabled = STATISTICS_ENABLED_EDEFAULT;
 
 	/**
+	 * The default value of the '{@link #getTransportJmsRetriesBeforeSuspension() <em>Transport Jms Retries Before Suspension</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJmsRetriesBeforeSuspension()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getTransportJmsRetriesBeforeSuspension() <em>Transport Jms Retries Before Suspension</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJmsRetriesBeforeSuspension()
+	 * @generated
+	 * @ordered
+	 */
+	protected String transportJmsRetriesBeforeSuspension = TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getTransportJmsPollingSuspensionPeriod() <em>Transport Jms Polling Suspension Period</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJmsPollingSuspensionPeriod()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getTransportJmsPollingSuspensionPeriod() <em>Transport Jms Polling Suspension Period</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJmsPollingSuspensionPeriod()
+	 * @generated
+	 * @ordered
+	 */
+	protected String transportJmsPollingSuspensionPeriod = TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD_EDEFAULT;
+
+	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated NOT
 	 */
@@ -6153,6 +6195,48 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 	}
 
 	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getTransportJmsRetriesBeforeSuspension() {
+		return transportJmsRetriesBeforeSuspension;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setTransportJmsRetriesBeforeSuspension(String newTransportJmsRetriesBeforeSuspension) {
+		String oldTransportJmsRetriesBeforeSuspension = transportJmsRetriesBeforeSuspension;
+		transportJmsRetriesBeforeSuspension = newTransportJmsRetriesBeforeSuspension;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION, oldTransportJmsRetriesBeforeSuspension, transportJmsRetriesBeforeSuspension));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getTransportJmsPollingSuspensionPeriod() {
+		return transportJmsPollingSuspensionPeriod;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setTransportJmsPollingSuspensionPeriod(String newTransportJmsPollingSuspensionPeriod) {
+		String oldTransportJmsPollingSuspensionPeriod = transportJmsPollingSuspensionPeriod;
+		transportJmsPollingSuspensionPeriod = newTransportJmsPollingSuspensionPeriod;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD, oldTransportJmsPollingSuspensionPeriod, transportJmsPollingSuspensionPeriod));
+	}
+
+	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
@@ -8135,6 +8219,10 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 				return isTraceEnabled();
 			case EsbPackage.INBOUND_ENDPOINT__STATISTICS_ENABLED:
 				return isStatisticsEnabled();
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION:
+				return getTransportJmsRetriesBeforeSuspension();
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD:
+				return getTransportJmsPollingSuspensionPeriod();
 		}
 		return super.eGet(featureID, resolve, coreType);
 	}
@@ -8709,6 +8797,12 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 			case EsbPackage.INBOUND_ENDPOINT__STATISTICS_ENABLED:
 				setStatisticsEnabled((Boolean)newValue);
 				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION:
+				setTransportJmsRetriesBeforeSuspension((String)newValue);
+				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD:
+				setTransportJmsPollingSuspensionPeriod((String)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -9281,6 +9375,12 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 			case EsbPackage.INBOUND_ENDPOINT__STATISTICS_ENABLED:
 				setStatisticsEnabled(STATISTICS_ENABLED_EDEFAULT);
 				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION:
+				setTransportJmsRetriesBeforeSuspension(TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION_EDEFAULT);
+				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD:
+				setTransportJmsPollingSuspensionPeriod(TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -9666,13 +9766,17 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 				return traceEnabled != TRACE_ENABLED_EDEFAULT;
 			case EsbPackage.INBOUND_ENDPOINT__STATISTICS_ENABLED:
 				return statisticsEnabled != STATISTICS_ENABLED_EDEFAULT;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION:
+				return TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION_EDEFAULT == null ? transportJmsRetriesBeforeSuspension != null : !TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION_EDEFAULT.equals(transportJmsRetriesBeforeSuspension);
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD:
+				return TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD_EDEFAULT == null ? transportJmsPollingSuspensionPeriod != null : !TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD_EDEFAULT.equals(transportJmsPollingSuspensionPeriod);
 		}
 		return super.eIsSet(featureID);
 	}
 
 	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
-	 * @generated 
+	 * @generated
 	 */
 	@Override
 	public String toString() {
@@ -10041,6 +10145,10 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 		result.append(traceEnabled);
 		result.append(", statisticsEnabled: ");
 		result.append(statisticsEnabled);
+		result.append(", transportJmsRetriesBeforeSuspension: ");
+		result.append(transportJmsRetriesBeforeSuspension);
+		result.append(", transportJmsPollingSuspensionPeriod: ");
+		result.append(transportJmsPollingSuspensionPeriod);
 		result.append(')');
 		return result.toString();
 	}


### PR DESCRIPTION
## Purpose
> Add the functionality to JMS inbound endpoints to suspend and reactivate polling when a certain number of mediation failures occur.

## Goals
> Fix wso2/devstudio-tooling-ei#110

## Approach
> Here we are introducing two new optional paramters for jms inbound endpoint to suspend polling for a specified amount of time after specified amount of failures.


## User stories
> N/A


## Related PRs
> Related product issue:wso2/product-ei#1622.
> update fix https://github.com/wso2/devstudio-tooling-esb/pull/296


## Test environment
> JDK 1.8 , ubuntu 16.04
