### PR TITLE
Add 'preservePolicy' attribute to publish WSDL

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/ProxyServiceDeserializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/ProxyServiceDeserializer.java
@@ -100,6 +100,14 @@ public class ProxyServiceDeserializer extends AbstractEsbNodeDeserializer<ProxyS
 			hasPublishWsdl=false;
 		}
 		
+		if (object.getPreservePolicy() != null) {
+			if (object.getPreservePolicy().equals("true")) {
+				executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, true);
+			} else {
+				executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, false);
+			}
+		}
+		
 		Endpoint targetInLineEndpoint = object.getTargetInLineEndpoint();
 		if(targetInLineEndpoint!=null){
 			setHasInlineEndPoint(true);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/ProxyServiceDeserializer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/deserializer/ProxyServiceDeserializer.java
@@ -100,12 +100,10 @@ public class ProxyServiceDeserializer extends AbstractEsbNodeDeserializer<ProxyS
 			hasPublishWsdl=false;
 		}
 		
-		if (object.getPreservePolicy() != null) {
-			if (object.getPreservePolicy().equals("true")) {
-				executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, true);
-			} else {
-				executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, false);
-			}
+		if("false".equals(object.getPreservePolicy())){
+			executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, false);
+		} else {
+			executeSetValueCommand(PROXY_SERVICE__PRESERVE_POLICY, true);
 		}
 		
 		Endpoint targetInLineEndpoint = object.getTargetInLineEndpoint();

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
@@ -2400,3 +2400,4 @@ _UI_APIVersionType_URL_literal = url
 _UI_InboundEndpoint_transportJMSRetriesBeforeSuspension_feature = Transport JMS Retries Before Suspension
 _UI_InboundEndpoint_transportJMSResetConnectionOnPollingSuspension_feature = Transport JMS Reset Connection On Polling Suspension
 _UI_InboundEndpoint_transportJMSPollingSuspensionPeriod_feature = Transport JMS Polling Suspension Period
+_UI_ProxyService_preservePolicy_feature = Preserve Policy

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/ProxyServiceItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/ProxyServiceItemProvider.java
@@ -98,9 +98,13 @@ public class ProxyServiceItemProvider
 				break;
 			}
 			}
-			if (proxy.getWsdlType() != ProxyWsdlType.NONE && proxy.getWsdlType() != ProxyWsdlType.ENDPOINT) {
-				addWsdlResourcesPropertyDescriptor(object);
+			if (proxy.getWsdlType() != ProxyWsdlType.NONE) {
+				addPreservePolicyPropertyDescriptor(object);
+				if (proxy.getWsdlType() != ProxyWsdlType.ENDPOINT) {
+					addWsdlResourcesPropertyDescriptor(object);
+				}
 			}
+			
 			addInSequenceTypePropertyDescriptor(object);
 			switch (proxy.getInSequenceType()) {
 			case REGISTRY_REFERENCE: {
@@ -447,6 +451,28 @@ public class ProxyServiceItemProvider
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 "WSDL",
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Preserve Policy feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated NOT
+	 */
+	protected void addPreservePolicyPropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_ProxyService_preservePolicy_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_ProxyService_preservePolicy_feature", "_UI_ProxyService_type"),
+				 EsbPackage.Literals.PROXY_SERVICE__PRESERVE_POLICY,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
 				 "WSDL",
 				 null));
 	}
@@ -1037,6 +1063,7 @@ public class ProxyServiceItemProvider
 			case EsbPackage.PROXY_SERVICE__ENDPOINT_NAME:
 			case EsbPackage.PROXY_SERVICE__MAIN_SEQUENCE:
 			case EsbPackage.PROXY_SERVICE__WSDL_TYPE:
+			case EsbPackage.PROXY_SERVICE__PRESERVE_POLICY:
 			case EsbPackage.PROXY_SERVICE__WSDL_XML:
 			case EsbPackage.PROXY_SERVICE__WSDL_URL:
 				fireNotifyChanged(new ViewerNotification(notification, notification.getNotifier(), false, true));

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/ProxyServiceTransformer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.persistence/src/org/wso2/developerstudio/eclipse/gmf/esb/internal/persistence/ProxyServiceTransformer.java
@@ -408,12 +408,17 @@ public class ProxyServiceTransformer extends AbstractEsbNodeTransformer {
 				break;
 			}
 			
-			if (visualService.getWsdlType()!=ProxyWsdlType.NONE && visualService.getWsdlType() != ProxyWsdlType.ENDPOINT) {
-				proxyService.setResourceMap(new ResourceMap());
-				for (ProxyWSDLResource wsdlResource : visualService.getWsdlResources()) {
-					proxyService.getResourceMap().addResource(wsdlResource.getLocation(),wsdlResource.getKey().getKeyValue());
+			if (visualService.getWsdlType() != ProxyWsdlType.NONE) {
+				setPreservePolicyValue(visualService, proxyService);
+				if (visualService.getWsdlType() != ProxyWsdlType.ENDPOINT) {
+					proxyService.setResourceMap(new ResourceMap());
+					for (ProxyWSDLResource wsdlResource : visualService.getWsdlResources()) {
+						proxyService.getResourceMap().addResource(wsdlResource.getLocation(),
+								wsdlResource.getKey().getKeyValue());
+					}
 				}
 			}
+		
 			String pinnedServerInfo = visualService.getPinnedServers();
 			if (pinnedServerInfo != null && !pinnedServerInfo.equals("")) {
 				for (String a : pinnedServerInfo.split(",")) {
@@ -553,6 +558,23 @@ public class ProxyServiceTransformer extends AbstractEsbNodeTransformer {
 			// operation (attempting to route one proxy service's messages to
 			// another).
 			// parentMediator.addChild(new SendMediator());
+		}
+	}
+	
+	/**
+	 * This sets the preserve policy value
+	 * 
+	 * @param visualService
+	 *            gmf model proxy service object
+	 * @param proxyService
+	 *            synapse proxy service object
+	 */
+	private void setPreservePolicyValue(org.wso2.developerstudio.eclipse.gmf.esb.ProxyService visualService,
+			ProxyService proxyService) {
+		if (visualService.isPreservePolicy()) {
+			proxyService.setPreservePolicy("true");
+		} else {
+			proxyService.setPreservePolicy("false");
 		}
 	}
 	

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
@@ -190,6 +190,8 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="mainSequence" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="wsdlType" eType="#//ProxyWsdlType"
         defaultValueLiteral="NONE"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="preservePolicy" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EBoolean"
+        defaultValueLiteral="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="wsdlXML" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"
         defaultValueLiteral="&lt;definitions/>"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="wsdlURL" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
@@ -1114,13 +1114,22 @@ public interface EsbPackage extends EPackage {
 	int PROXY_SERVICE__WSDL_TYPE = ESB_ELEMENT_FEATURE_COUNT + 33;
 
 	/**
+	 * The feature id for the '<em><b>Preserve Policy</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PROXY_SERVICE__PRESERVE_POLICY = ESB_ELEMENT_FEATURE_COUNT + 34;
+
+	/**
 	 * The feature id for the '<em><b>Wsdl XML</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__WSDL_XML = ESB_ELEMENT_FEATURE_COUNT + 34;
+	int PROXY_SERVICE__WSDL_XML = ESB_ELEMENT_FEATURE_COUNT + 35;
 
 	/**
 	 * The feature id for the '<em><b>Wsdl URL</b></em>' attribute.
@@ -1129,7 +1138,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__WSDL_URL = ESB_ELEMENT_FEATURE_COUNT + 35;
+	int PROXY_SERVICE__WSDL_URL = ESB_ELEMENT_FEATURE_COUNT + 36;
 
 	/**
 	 * The feature id for the '<em><b>Wsdl Key</b></em>' containment reference.
@@ -1138,7 +1147,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__WSDL_KEY = ESB_ELEMENT_FEATURE_COUNT + 36;
+	int PROXY_SERVICE__WSDL_KEY = ESB_ELEMENT_FEATURE_COUNT + 37;
 
 	/**
 	 * The feature id for the '<em><b>Wsdl Endpoint</b></em>' containment reference.
@@ -1147,7 +1156,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__WSDL_ENDPOINT = ESB_ELEMENT_FEATURE_COUNT + 37;
+	int PROXY_SERVICE__WSDL_ENDPOINT = ESB_ELEMENT_FEATURE_COUNT + 38;
 
 	/**
 	 * The feature id for the '<em><b>Wsdl Resources</b></em>' containment reference list.
@@ -1156,7 +1165,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__WSDL_RESOURCES = ESB_ELEMENT_FEATURE_COUNT + 38;
+	int PROXY_SERVICE__WSDL_RESOURCES = ESB_ELEMENT_FEATURE_COUNT + 39;
 
 	/**
 	 * The feature id for the '<em><b>On Error</b></em>' containment reference.
@@ -1165,7 +1174,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE__ON_ERROR = ESB_ELEMENT_FEATURE_COUNT + 39;
+	int PROXY_SERVICE__ON_ERROR = ESB_ELEMENT_FEATURE_COUNT + 40;
 
 	/**
 	 * The number of structural features of the '<em>Proxy Service</em>' class.
@@ -1174,7 +1183,7 @@ public interface EsbPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROXY_SERVICE_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 40;
+	int PROXY_SERVICE_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 41;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyOutputConnectorImpl <em>Proxy Output Connector</em>}' class.
@@ -27492,6 +27501,17 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	EAttribute getProxyService_WsdlType();
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#isPreservePolicy <em>Preserve Policy</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Preserve Policy</em>'.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#isPreservePolicy()
+	 * @see #getProxyService()
+	 * @generated
+	 */
+	EAttribute getProxyService_PreservePolicy();
+
+	/**
 	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getWsdlXML <em>Wsdl XML</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -45078,6 +45098,14 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 		 * @generated
 		 */
 		EAttribute PROXY_SERVICE__WSDL_TYPE = eINSTANCE.getProxyService_WsdlType();
+
+		/**
+		 * The meta object literal for the '<em><b>Preserve Policy</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute PROXY_SERVICE__PRESERVE_POLICY = eINSTANCE.getProxyService_PreservePolicy();
 
 		/**
 		 * The meta object literal for the '<em><b>Wsdl XML</b></em>' attribute feature.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/ProxyService.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/ProxyService.java
@@ -52,6 +52,7 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getEndpointName <em>Endpoint Name</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#isMainSequence <em>Main Sequence</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getWsdlType <em>Wsdl Type</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#isPreservePolicy <em>Preserve Policy</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getWsdlXML <em>Wsdl XML</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getWsdlURL <em>Wsdl URL</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#getWsdlKey <em>Wsdl Key</em>}</li>
@@ -938,6 +939,33 @@ public interface ProxyService extends EsbElement {
 	 * @generated
 	 */
 	void setWsdlType(ProxyWsdlType value);
+
+	/**
+	 * Returns the value of the '<em><b>Preserve Policy</b></em>' attribute.
+	 * The default value is <code>"true"</code>.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Preserve Policy</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Preserve Policy</em>' attribute.
+	 * @see #setPreservePolicy(boolean)
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getProxyService_PreservePolicy()
+	 * @model default="true"
+	 * @generated
+	 */
+	boolean isPreservePolicy();
+
+	/**
+	 * Sets the value of the '{@link org.wso2.developerstudio.eclipse.gmf.esb.ProxyService#isPreservePolicy <em>Preserve Policy</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Preserve Policy</em>' attribute.
+	 * @see #isPreservePolicy()
+	 * @generated
+	 */
+	void setPreservePolicy(boolean value);
 
 	/**
 	 * Returns the value of the '<em><b>Wsdl XML</b></em>' attribute.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
@@ -4809,7 +4809,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getProxyService_WsdlXML() {
+	public EAttribute getProxyService_PreservePolicy() {
 		return (EAttribute)proxyServiceEClass.getEStructuralFeatures().get(34);
 	}
 
@@ -4818,7 +4818,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getProxyService_WsdlURL() {
+	public EAttribute getProxyService_WsdlXML() {
 		return (EAttribute)proxyServiceEClass.getEStructuralFeatures().get(35);
 	}
 
@@ -4827,8 +4827,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getProxyService_WsdlKey() {
-		return (EReference)proxyServiceEClass.getEStructuralFeatures().get(36);
+	public EAttribute getProxyService_WsdlURL() {
+		return (EAttribute)proxyServiceEClass.getEStructuralFeatures().get(36);
 	}
 
 	/**
@@ -4836,7 +4836,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getProxyService_WsdlEndpoint() {
+	public EReference getProxyService_WsdlKey() {
 		return (EReference)proxyServiceEClass.getEStructuralFeatures().get(37);
 	}
 
@@ -4845,7 +4845,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getProxyService_WsdlResources() {
+	public EReference getProxyService_WsdlEndpoint() {
 		return (EReference)proxyServiceEClass.getEStructuralFeatures().get(38);
 	}
 
@@ -4854,8 +4854,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EReference getProxyService_OnError() {
+	public EReference getProxyService_WsdlResources() {
 		return (EReference)proxyServiceEClass.getEStructuralFeatures().get(39);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EReference getProxyService_OnError() {
+		return (EReference)proxyServiceEClass.getEStructuralFeatures().get(40);
 	}
 
 	/**
@@ -19108,6 +19117,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		createEAttribute(proxyServiceEClass, PROXY_SERVICE__ENDPOINT_NAME);
 		createEAttribute(proxyServiceEClass, PROXY_SERVICE__MAIN_SEQUENCE);
 		createEAttribute(proxyServiceEClass, PROXY_SERVICE__WSDL_TYPE);
+		createEAttribute(proxyServiceEClass, PROXY_SERVICE__PRESERVE_POLICY);
 		createEAttribute(proxyServiceEClass, PROXY_SERVICE__WSDL_XML);
 		createEAttribute(proxyServiceEClass, PROXY_SERVICE__WSDL_URL);
 		createEReference(proxyServiceEClass, PROXY_SERVICE__WSDL_KEY);
@@ -21511,6 +21521,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		initEAttribute(getProxyService_EndpointName(), ecorePackage.getEString(), "endpointName", null, 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getProxyService_MainSequence(), ecorePackage.getEBoolean(), "mainSequence", null, 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getProxyService_WsdlType(), this.getProxyWsdlType(), "wsdlType", "NONE", 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getProxyService_PreservePolicy(), ecorePackage.getEBoolean(), "preservePolicy", "true", 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getProxyService_WsdlXML(), ecorePackage.getEString(), "wsdlXML", "<definitions/>", 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getProxyService_WsdlURL(), ecorePackage.getEString(), "wsdlURL", "http://default/wsdl/url", 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getProxyService_WsdlKey(), this.getRegistryKeyProperty(), null, "wsdlKey", null, 0, 1, ProxyService.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/ProxyServiceImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/ProxyServiceImpl.java
@@ -90,6 +90,7 @@ import org.wso2.developerstudio.eclipse.platform.core.utils.DeveloperStudioProvi
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#getEndpointName <em>Endpoint Name</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#isMainSequence <em>Main Sequence</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#getWsdlType <em>Wsdl Type</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#isPreservePolicy <em>Preserve Policy</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#getWsdlXML <em>Wsdl XML</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#getWsdlURL <em>Wsdl URL</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.ProxyServiceImpl#getWsdlKey <em>Wsdl Key</em>}</li>
@@ -630,6 +631,26 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 	 * @ordered
 	 */
 	protected ProxyWsdlType wsdlType = WSDL_TYPE_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #isPreservePolicy() <em>Preserve Policy</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isPreservePolicy()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final boolean PRESERVE_POLICY_EDEFAULT = true;
+
+	/**
+	 * The cached value of the '{@link #isPreservePolicy() <em>Preserve Policy</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #isPreservePolicy()
+	 * @generated
+	 * @ordered
+	 */
+	protected boolean preservePolicy = PRESERVE_POLICY_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getWsdlXML() <em>Wsdl XML</em>}' attribute.
@@ -1762,6 +1783,27 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public boolean isPreservePolicy() {
+		return preservePolicy;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setPreservePolicy(boolean newPreservePolicy) {
+		boolean oldPreservePolicy = preservePolicy;
+		preservePolicy = newPreservePolicy;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, EsbPackage.PROXY_SERVICE__PRESERVE_POLICY, oldPreservePolicy, preservePolicy));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public String getWsdlXML() {
 		return wsdlXML;
 	}
@@ -2068,6 +2110,8 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 				return isMainSequence();
 			case EsbPackage.PROXY_SERVICE__WSDL_TYPE:
 				return getWsdlType();
+			case EsbPackage.PROXY_SERVICE__PRESERVE_POLICY:
+				return isPreservePolicy();
 			case EsbPackage.PROXY_SERVICE__WSDL_XML:
 				return getWsdlXML();
 			case EsbPackage.PROXY_SERVICE__WSDL_URL:
@@ -2198,6 +2242,9 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 				return;
 			case EsbPackage.PROXY_SERVICE__WSDL_TYPE:
 				setWsdlType((ProxyWsdlType)newValue);
+				return;
+			case EsbPackage.PROXY_SERVICE__PRESERVE_POLICY:
+				setPreservePolicy((Boolean)newValue);
 				return;
 			case EsbPackage.PROXY_SERVICE__WSDL_XML:
 				setWsdlXML((String)newValue);
@@ -2333,6 +2380,9 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 			case EsbPackage.PROXY_SERVICE__WSDL_TYPE:
 				setWsdlType(WSDL_TYPE_EDEFAULT);
 				return;
+			case EsbPackage.PROXY_SERVICE__PRESERVE_POLICY:
+				setPreservePolicy(PRESERVE_POLICY_EDEFAULT);
+				return;
 			case EsbPackage.PROXY_SERVICE__WSDL_XML:
 				setWsdlXML(WSDL_XML_EDEFAULT);
 				return;
@@ -2432,6 +2482,8 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 				return mainSequence != MAIN_SEQUENCE_EDEFAULT;
 			case EsbPackage.PROXY_SERVICE__WSDL_TYPE:
 				return wsdlType != WSDL_TYPE_EDEFAULT;
+			case EsbPackage.PROXY_SERVICE__PRESERVE_POLICY:
+				return preservePolicy != PRESERVE_POLICY_EDEFAULT;
 			case EsbPackage.PROXY_SERVICE__WSDL_XML:
 				return WSDL_XML_EDEFAULT == null ? wsdlXML != null : !WSDL_XML_EDEFAULT.equals(wsdlXML);
 			case EsbPackage.PROXY_SERVICE__WSDL_URL:
@@ -2497,6 +2549,8 @@ public class ProxyServiceImpl extends EsbElementImpl implements ProxyService {
 		result.append(mainSequence);
 		result.append(", wsdlType: ");
 		result.append(wsdlType);
+		result.append(", preservePolicy: ");
+		result.append(preservePolicy);
 		result.append(", wsdlXML: ");
 		result.append(wsdlXML);
 		result.append(", wsdlURL: ");


### PR DESCRIPTION
## Purpose
> Attribute 'preservePolicy'  is missing in the publish WSDL of the proxy service. Fixes wso2/devstudio-tooling-ei#137 

## Goals
> Added preservePolicy attribute

## Test environment
> JDK 8, Ubuntu 16.04
