### PR TITLE
Fix wso2/product-ei/issues/2386

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/action/Messages.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/action/Messages.java
@@ -59,6 +59,7 @@ public class Messages extends NLS {
 	public static String SchemaFromJsonAction_menuTitle;
 	public static String SchemaFromJsonAction_sampleJsonFile;
 	public static String SchemaKeyEditorDialog_SelecSchemaSource;
+	public static String SchemaKeyEditorDialog_EnterDelimiter;
 	public static String SchemaKeyEditorDialog_SelectConnector;
 	public static String SchemaKeyEditorDialog_SelectConnectorOperation;
 	public static String SchemaKeyEditorDialog_GenerateSchema;

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/action/messages.properties
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/action/messages.properties
@@ -34,6 +34,7 @@ SchemaFromJsonAction_menuTitle=Generate schema using a json dataset
 SchemaFromJsonAction_errorTitle=Error
 SchemaFromJsonAction_sampleJsonFile=Sample json file
 SchemaKeyEditorDialog_SelecSchemaSource=Resource Type  :
+SchemaKeyEditorDialog_EnterDelimiter=Delimiter  :
 SchemaKeyEditorDialog_EmbeddedResources=Embedded Resources
 SchemaKeyEditorDialog_ErrorMsgHeader=Error\!
 SchemaKeyEditorDialog_ErrorOpeningFile=Error occurred while opening file.

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/SchemaKeyEditorDialog.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/SchemaKeyEditorDialog.java
@@ -97,6 +97,8 @@ public class SchemaKeyEditorDialog extends Dialog {
     private static final String FILE_DIALOG_TITLE = "Select File";
     private Text schemaKeyTextField;
     private Label lblSchemaTypeLabel;
+    private Label lblDelimiterLabel;
+    private Text delimiterTextField;
     private Combo schemaTypeCombo;
     private EditPart selectedEP;
     private IFile inputFile;
@@ -135,6 +137,9 @@ public class SchemaKeyEditorDialog extends Dialog {
     private static final String WORKSPACE = "workspace"; //$NON-NLS-1$
     private static final String REGISTRY = "registry"; //$NON-NLS-1$
     private static final String FILE_SYSTEM = "file system"; //$NON-NLS-1$
+    
+    private static final String DELIMITER = "delimiter";
+    private static final String DEFAULT_DELIMITER = ",";
 
     private static final String ERROR_MSG_HEADER = Messages.SchemaKeyEditorDialog_ErrorMsgHeader;
     private static final String SCHEMA_KEY_EDITOR_DIALOG_TEXT =
@@ -159,6 +164,8 @@ public class SchemaKeyEditorDialog extends Dialog {
             Messages.SchemaKeyEditorDialog_ReasonRegistryURL;
     private static final String SELECT_SCHEMA_SOURCE =
             Messages.SchemaKeyEditorDialog_SelecSchemaSource;
+    private static final String ENTER_DELIMITER = 
+    		Messages.SchemaKeyEditorDialog_EnterDelimiter;
     private static final String ERROR_DIALOG_VISIBILITY =
             Messages.SchemaKeyEditorFialog_VisibilityError; // $NON-NLS-1$
     private static final String SELECT_CONNECTOR = Messages.SchemaKeyEditorDialog_SelectConnector;
@@ -231,6 +238,10 @@ public class SchemaKeyEditorDialog extends Dialog {
         // initialize components
         lblSchemaTypeLabel = new Label(grpPropertyKey, SWT.NORMAL);
         schemaTypeCombo = new Combo(grpPropertyKey, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER);
+        
+        lblDelimiterLabel = new Label(grpPropertyKey,SWT.NORMAL);
+        delimiterTextField = new Text(grpPropertyKey,SWT.BORDER);
+        
         lblConnector = new Label(grpPropertyKey, SWT.NORMAL);
         lblConnectorOperation = new Label(grpPropertyKey, SWT.NORMAL);
         cmbConnector = new Combo(grpPropertyKey, SWT.DROP_DOWN | SWT.READ_ONLY | SWT.BORDER);
@@ -261,6 +272,19 @@ public class SchemaKeyEditorDialog extends Dialog {
                     generateSchema.setVisible(false);
                     link.setVisible(false);
                     schemaKeyTextField.setVisible(false);
+                    lblDelimiterLabel.setVisible(false);
+                    delimiterTextField.setVisible(false);
+                    grpPropertyKey.redraw();
+                } else if (FileType.CSV.toString().equals(schemaTypeCombo.getText())) {
+                    lblConnector.setVisible(false);
+                    lblConnectorOperation.setVisible(false);
+                    cmbConnector.setVisible(false);
+                    cmbConnectorOperation.setVisible(false);
+                    generateSchema.setVisible(false);
+                    link.setVisible(true);
+                    schemaKeyTextField.setVisible(true);
+                    lblDelimiterLabel.setVisible(true);
+                    delimiterTextField.setVisible(true);
                     grpPropertyKey.redraw();
                 } else {
                     lblConnector.setVisible(false);
@@ -270,6 +294,8 @@ public class SchemaKeyEditorDialog extends Dialog {
                     generateSchema.setVisible(false);
                     link.setVisible(true);
                     schemaKeyTextField.setVisible(true);
+                    lblDelimiterLabel.setVisible(false);
+                    delimiterTextField.setVisible(false);
                     grpPropertyKey.redraw();
                 }
             }
@@ -282,7 +308,17 @@ public class SchemaKeyEditorDialog extends Dialog {
         schemaTypeCombo.setItems(options);
         schemaTypeCombo.select(0);
         schemaTypeCombo.setLayoutData(comboLayoutData);
-
+        
+        FormData delimiterLabelLayout = new FormData();
+        delimiterLabelLayout.left = new FormAttachment(schemaTypeCombo, 10, SWT.RIGHT);
+        lblDelimiterLabel.setText(ENTER_DELIMITER);
+        lblDelimiterLabel.setLayoutData(delimiterLabelLayout);
+        
+        FormData delimiterTextFieldLayout = new FormData();
+        delimiterTextFieldLayout.left = new FormAttachment(lblDelimiterLabel, 10, SWT.RIGHT);
+        delimiterTextField.setLayoutData(delimiterTextFieldLayout);
+        delimiterTextField.setText(DEFAULT_DELIMITER);
+        
         FormData connectorLabelLayoutData = new FormData();
         connectorLabelLayoutData.top = new FormAttachment(lblSchemaTypeLabel, 20, SWT.BOTTOM);
 
@@ -573,7 +609,7 @@ public class SchemaKeyEditorDialog extends Dialog {
             }
 
             String schema = schemaGeneratorHelper.getSchemaContent(FileType.JSONSCHEMA,
-                    schemaFilePath);
+                    schemaFilePath, null);
             DataMapperSchemaEditorUtil schemaEditorUtil = new DataMapperSchemaEditorUtil(inputFile);
             if (schema != null) {
                 String schemaSaveFilePath = schemaEditorUtil.createDiagram(schema, schemaType);
@@ -586,7 +622,7 @@ public class SchemaKeyEditorDialog extends Dialog {
                 DataMapperSchemaEditorUtil schemaEditorUtil1 =
                         new DataMapperSchemaEditorUtil(inputFile);
                 String schema1 = schemaGeneratorHelper.getSchemaContent(FileType.XML,
-                        rootWorkspaceLocation);
+                        rootWorkspaceLocation, null);
                 file.delete();
                 if (schema1 != null) {
                     String schemaSaveFilePath1 =
@@ -686,7 +722,8 @@ public class SchemaKeyEditorDialog extends Dialog {
 
                 boolean isCompatible = checkFileExtensionAgainstTheSchemaType(fileType);
                 if (isCompatible) {
-                    String schema = schemaGeneratorHelper.getSchemaContent(fileType, resourceFile);
+                    String schema = 
+                    		schemaGeneratorHelper.getSchemaContent(fileType, resourceFile, delimiterTextField.getText());
                     String schemaFilePath = null;
                     try {
                         schemaFilePath = schemaEditorUtil.createDiagram(schema, schemaType);
@@ -815,7 +852,7 @@ public class SchemaKeyEditorDialog extends Dialog {
             if (isCompatible) {
                 String schema =
                         schemaGeneratorHelper.getSchemaContent(FileType.values()[schemaTypeCombo.getSelectionIndex()],
-                                outputFile.getAbsolutePath());
+                                outputFile.getAbsolutePath(),delimiterTextField.getText());
                 outputDirectory.deleteOnExit();
                 String schemaFilePath = schemaEditorUtil.createDiagram(schema, schemaType);
 
@@ -909,7 +946,7 @@ public class SchemaKeyEditorDialog extends Dialog {
 
             String schema =
                     schemaGeneratorHelper.getSchemaContent(FileType.values()[schemaTypeCombo.getSelectionIndex()],
-                            filePath);
+                            filePath, delimiterTextField.getText());
             if (schema != null) {
                 String schemaFilePath = schemaEditorUtil.createDiagram(schema, schemaType);
                 if (!schemaFilePath.isEmpty()) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/AbstractSchemaGenerator.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/AbstractSchemaGenerator.java
@@ -28,7 +28,7 @@ public class AbstractSchemaGenerator implements ISchemaGenerator {
 	 * @see org.wso2.developerstudio.datamapper.diagram.schemagen.util.ISchemaGenerator#getAvroSchema(java.lang.String)
 	 */
 	@Override
-	public String getSchemaResourcePath(String filePath, FileType type) throws IOException {
+	public String getSchemaResourcePath(String filePath, FileType type, String delimiter) throws IOException {
 
 		String entireFileText = FileUtils.readFileToString(new File(filePath));
 		//Schema schema = Schema.parse(entireFileText);
@@ -40,7 +40,7 @@ public class AbstractSchemaGenerator implements ISchemaGenerator {
 	 * @see org.wso2.developerstudio.datamapper.diagram.schemagen.util.ISchemaGenerator#getAvroSchemaContent(java.lang.String)
 	 */
 	@Override
-	public String getSchemaContent(String fileText, FileType type) throws IOException {
+	public String getSchemaContent(String fileText, FileType type, String delimiter) throws IOException {
 		Schema schema = Schema.parse(fileText);//TODO remove the deprecated method usage
 		return schema.toString();
 	}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/ISchemaGenerator.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/ISchemaGenerator.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 
 public interface ISchemaGenerator {
 
-	public abstract String getSchemaResourcePath(String filePath,FileType type) throws IOException;
+	public abstract String getSchemaResourcePath(String filePath,FileType type, String delimiter) throws IOException;
 
-	public abstract String getSchemaContent(String fileText, FileType type) throws IOException;
+	public abstract String getSchemaContent(String fileText, FileType type, String delimiter) throws IOException;
 
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForCSV.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForCSV.java
@@ -31,14 +31,14 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 public class SchemaGeneratorForCSV extends AbstractSchemaGenerator implements ISchemaGenerator {
 
 	@Override
-	public String getSchemaResourcePath(String filePath, FileType type) throws IOException {
+	public String getSchemaResourcePath(String filePath, FileType type, String delimiter) throws IOException {
 		String entireFileText = FileUtils.readFileToString(new File(filePath));
-		return getSchemaContent(entireFileText, type);
+		return getSchemaContent(entireFileText, type, delimiter);
 	}
 
 	@Override
-	public String getSchemaContent(String fileText, FileType type) throws IOException {
-		List<Map<String, String>> data = readObjectsFromCsv(fileText);
+	public String getSchemaContent(String fileText, FileType type, String delimiter) throws IOException {
+		List<Map<String, String>> data = readObjectsFromCsv(fileText, delimiter);
 		String value = writeAsJson(data);
 		SchemaBuilderWithNamepaces sb = new SchemaBuilderWithNamepaces();
 		String jsonSchema = sb.createSchema(value, type);
@@ -52,9 +52,13 @@ public class SchemaGeneratorForCSV extends AbstractSchemaGenerator implements IS
 	 * @return
 	 * @throws IOException
 	 */
-	public List<Map<String, String>> readObjectsFromCsv(String content) throws IOException {
+	public List<Map<String, String>> readObjectsFromCsv(String content, String delimiter) throws IOException {
 		CsvMapper mapper = new CsvMapper();
-		CsvSchema schema = CsvSchema.emptySchema().withHeader();
+		char delimiterChar =',';
+		if (!delimiter.isEmpty()) {
+			delimiterChar = delimiter.charAt(0);
+		}
+		CsvSchema schema = CsvSchema.emptySchema().withHeader().withColumnSeparator(delimiterChar);
 		MappingIterator<Map<String, String>> it = mapper.readerFor(Map.class).with(schema).readValues(content);
 		return it.readAll();
 	}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForJSON.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForJSON.java
@@ -24,13 +24,13 @@ import org.apache.commons.io.FileUtils;
 public class SchemaGeneratorForJSON extends AbstractSchemaGenerator implements ISchemaGenerator {
 
 	@Override
-	public String getSchemaResourcePath(String filePath, FileType type) throws IOException {
+	public String getSchemaResourcePath(String filePath, FileType type, String delimiter) throws IOException {
 		String entireFileText = FileUtils.readFileToString(new File(filePath));
-		return  getSchemaContent(entireFileText, type);
+		return  getSchemaContent(entireFileText, type, null);
 	}
 
 	@Override
-	public String getSchemaContent(String fileText, FileType type) throws IOException {
+	public String getSchemaContent(String fileText, FileType type, String delimiter) throws IOException {
 		SchemaBuilderWithNamepaces sb = new SchemaBuilderWithNamepaces();
 		String jsonSchema = sb.createSchema(fileText, type);
 		return  jsonSchema;

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXML.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXML.java
@@ -53,7 +53,7 @@ public class SchemaGeneratorForXML extends SchemaGeneratorForJSON implements ISc
 	protected static final String XSI_TYPE = "type";
 
 	@Override
-	public String getSchemaContent(String content, FileType type) throws IOException {
+	public String getSchemaContent(String content, FileType type, String delimiter) throws IOException {
 
 		JSONObject xmlJSONObj;
 		try {
@@ -62,7 +62,7 @@ public class SchemaGeneratorForXML extends SchemaGeneratorForJSON implements ISc
 			throw new IOException(e.getMessage());
 		}
 
-		return super.getSchemaContent(xmlJSONObj.toString(), type);
+		return super.getSchemaContent(xmlJSONObj.toString(), type, null);
 	}
 
 	/*
@@ -88,10 +88,10 @@ public class SchemaGeneratorForXML extends SchemaGeneratorForJSON implements ISc
 	 */
 
 	@Override
-	public String getSchemaResourcePath(String filePath, FileType type) throws IOException {
+	public String getSchemaResourcePath(String filePath, FileType type, String delimiter) throws IOException {
 		String entireFileText = FileUtils.readFileToString(new File(filePath));
 		entireFileText = replaceAttributesWithElements(entireFileText);
-		return getSchemaContent(entireFileText, type);
+		return getSchemaContent(entireFileText, type, null);
 	}
 
 	private String replaceAttributesWithElements(String entireFileText) throws IOException {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXSD.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXSD.java
@@ -41,7 +41,7 @@ public class SchemaGeneratorForXSD extends AbstractSchemaGenerator implements IS
 	private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
 
 	@Override
-	public String getSchemaContent(String filePath, FileType option) throws IOException {
+	public String getSchemaContent(String filePath, FileType option, String delimiter) throws IOException {
 		String schemaContent = null;
 		File xsdFile = new File(filePath);
 		InputStream xsdInputStream = new FileInputStream(xsdFile);
@@ -57,7 +57,7 @@ public class SchemaGeneratorForXSD extends AbstractSchemaGenerator implements IS
 				if (generatedXMLContent != null) {
 					String xmlSchemaContent = XML_VERSION_1_0_ENCODING_UTF_8 + generatedXMLContent;
 					SchemaGeneratorForXML schemaGeneratorForXML = new SchemaGeneratorForXML();
-					schemaContent = schemaGeneratorForXML.getSchemaContent(xmlSchemaContent, FileType.XML);
+					schemaContent = schemaGeneratorForXML.getSchemaContent(xmlSchemaContent, FileType.XML, null);
 				}
 				deleteRegResourcesCreated(xsdRegResource);
 			} catch (Exception e) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorHelper.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorHelper.java
@@ -40,20 +40,20 @@ public class SchemaGeneratorHelper {
 	 * @param filePath
 	 * @return
 	 */
-	public String getSchemaContent(FileType option, String filePath) {
+	public String getSchemaContent(FileType option, String filePath, String delimiter) {
 
 		SchemaGeneratorFactory schemaGenFactory = new SchemaGeneratorFactory();
 		ISchemaGenerator schemaGenerator = schemaGenFactory.getSchemaGenerator(option);
 
 		if (schemaGenerator instanceof SchemaGeneratorForXSD) {
 			try {
-				return schemaGenerator.getSchemaContent(filePath, option);
+				return schemaGenerator.getSchemaContent(filePath, option, null);
 			} catch (IOException e) {
 				log.error("Error while generating schema", e);
 			}
 		} else {
 			try {
-				return schemaGenerator.getSchemaResourcePath(filePath, option);
+				return schemaGenerator.getSchemaResourcePath(filePath, option, delimiter);
 			} catch (IOException e) {
 				log.error("Error while generating schema", e);
 			}


### PR DESCRIPTION
## Purpose
> Enabling to specify custom delimiters in datamapper CSV configs.

## Goals
> Datamapper should support csv files with other delimiter characters than ","

## Approach
> Take the delimiter as a user input

## User stories
> Enter delimiter in the given text box if it is something other than ","
