### PR TITLE
add default properties to JMS Inbound Endpoint for a given broker

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/META-INF/MANIFEST.MF
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/META-INF/MANIFEST.MF
@@ -13,5 +13,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.wso2.developerstudio.eclipse.gmf.esb;visibility:=reexport,
  org.eclipse.emf.edit;visibility:=reexport,
  org.eclipse.emf.common.ui;bundle-version="2.6.0",
- org.eclipse.emf.edit.ui;bundle-version="2.6.0"
+ org.eclipse.emf.edit.ui;bundle-version="2.6.0",
+ org.eclipse.emf.transaction
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/plugin.properties
@@ -2422,3 +2422,7 @@ _UI_InboundEndpoint_wssSslProtocols_feature = Wss Ssl Protocols
 _UI_InboundEndpoint_wssSslCipherSuites_feature = Wss Ssl Cipher Suites
 _UI_InboundEndpoint_transportRabbitMqConsumerQosKey_feature = Transport Rabbit Mq Consumer Qos Key
 _UI_InboundEndpoint_transportRabbitMqConsumerQosType_feature = Transport Rabbit Mq Consumer Qos Type
+_UI_InboundEndpoint_transportJMSBrokerType_feature = Transport JMS Broker Type
+_UI_JMSBrokerType_WSO2_BROKER_PROFILE_literal = WSO2_BROKER_PROFILE
+_UI_JMSBrokerType_ActiveMQ_literal = ActiveMQ
+_UI_JMSBrokerType_OTHER_literal = OTHER

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/InboundEndpointItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/InboundEndpointItemProvider.java
@@ -29,6 +29,9 @@ import org.wso2.developerstudio.eclipse.gmf.esb.EsbFactory;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
 import org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint;
 import org.wso2.developerstudio.eclipse.gmf.esb.PayloadFormatType;
+import org.eclipse.emf.transaction.RecordingCommand;
+import org.eclipse.emf.transaction.TransactionalEditingDomain; 
+import org.eclipse.emf.transaction.util.TransactionUtil;
 
 /**
  * This is the item provider adapter for a
@@ -38,6 +41,16 @@ import org.wso2.developerstudio.eclipse.gmf.esb.PayloadFormatType;
  * @generated
  */
 public class InboundEndpointItemProvider extends EsbElementItemProvider {
+	
+	private static final String JAVA_NAMING_FACTORY_INITIAL_WSO2_BROKER = "org.wso2.andes.jndi.PropertiesFileInitialContextFactory";
+	private static final String JAVA_NAMING_FACTORY_INITIAL_ACTIVEMQ = "org.apache.activemq.jndi.ActiveMQInitialContextFactory";
+	private static final String CONNECTION_FACTORY_JNDI_NAME_WSO2_BROKER = "QueueConnectionFactory";
+	private static final String CONNECTION_FACTORY_JNDI_NAME_ACTIVEMQ = "QueueConnectionFactory";
+	private static final String TRANSPORT_JMS_DESTINATION_WSO2_BROKER = "JMSMS";
+	private static final String TRANSPORT_JMS_DESTINATION_ACTIVEMQ = "ordersQueue";
+	private static final String JAVA_NAMING_PROVIDER_URL_WSO2_BROKER = "conf/jndi.properties";
+	private static final String JAVA_NAMING_PROVIDER_URL_ACTIVEMQ = "tcp://localhost:61616";
+	
 	/**
 	 * This constructs an instance from a factory and a notifier. <!--
 	 * begin-user-doc --> <!-- end-user-doc -->
@@ -141,6 +154,29 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 			addTransportJMSResetConnectionOnPollingSuspensionPropertyDescriptor(object);
 			addTransportJMSRetriesBeforeSuspensionPropertyDescriptor(object);
 			addTransportJMSPollingSuspensionPeriodPropertyDescriptor(object);
+			addTransportJMSBrokerTypePropertyDescriptor(object);
+			
+			switch (inboundEndpoint.getTransportJMSBrokerType()) {
+			case WSO2_BROKER_PROFILE:
+				updateJavaNamingFactoryInitialProperty(inboundEndpoint,JAVA_NAMING_FACTORY_INITIAL_WSO2_BROKER);
+				updateJavaNamingProviderUrlProperty(inboundEndpoint, JAVA_NAMING_PROVIDER_URL_WSO2_BROKER);
+				updateTransportJMSDestinationProperty(inboundEndpoint, TRANSPORT_JMS_DESTINATION_WSO2_BROKER);
+				updateTransportJMSConnectionFactoryJNDINameProperty(inboundEndpoint, CONNECTION_FACTORY_JNDI_NAME_WSO2_BROKER);
+				break;
+			case ACTIVE_MQ:
+				updateJavaNamingFactoryInitialProperty(inboundEndpoint,JAVA_NAMING_FACTORY_INITIAL_ACTIVEMQ);
+				updateJavaNamingProviderUrlProperty(inboundEndpoint, JAVA_NAMING_PROVIDER_URL_ACTIVEMQ);
+				updateTransportJMSDestinationProperty(inboundEndpoint, TRANSPORT_JMS_DESTINATION_ACTIVEMQ);
+				updateTransportJMSConnectionFactoryJNDINameProperty(inboundEndpoint, CONNECTION_FACTORY_JNDI_NAME_ACTIVEMQ);
+				break;
+			case OTHER:
+				updateJavaNamingFactoryInitialProperty(inboundEndpoint,"");
+				updateJavaNamingProviderUrlProperty(inboundEndpoint, "");
+				updateTransportJMSDestinationProperty(inboundEndpoint, "");
+				updateTransportJMSConnectionFactoryJNDINameProperty(inboundEndpoint, "");
+				break;
+			}
+			
 			break;
 		case CUSTOM:
 			addClassPropertyDescriptor(object);
@@ -2566,7 +2602,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -2588,7 +2624,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -2610,7 +2646,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -3509,7 +3545,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.BOOLEAN_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -3531,7 +3567,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -3553,7 +3589,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -3874,7 +3910,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -3957,7 +3993,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_InboundEndpoint_transportJMSUserName_feature"),
 				getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJMSUserName_feature",
 						"_UI_InboundEndpoint_type"), EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_USER_NAME,
-				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -3973,7 +4009,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_InboundEndpoint_transportJMSPassword_feature"),
 				getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJMSPassword_feature",
 						"_UI_InboundEndpoint_type"), EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_PASSWORD,
-				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -3990,7 +4026,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_PropertyDescriptor_description",
 						"_UI_InboundEndpoint_transportJMSJMSSpecVersion_feature", "_UI_InboundEndpoint_type"),
 				EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMSJMS_SPEC_VERSION, true, false, false,
-				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4007,7 +4043,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_PropertyDescriptor_description",
 						"_UI_InboundEndpoint_transportJMSSubscriptionDurable_feature", "_UI_InboundEndpoint_type"),
 				EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_SUBSCRIPTION_DURABLE, true, false, false,
-				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4026,7 +4062,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 								"_UI_InboundEndpoint_transportJMSDurableSubscriberClientID_feature",
 								"_UI_InboundEndpoint_type"),
 						EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_CLIENT_ID, true, false,
-						false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+						false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4043,7 +4079,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_PropertyDescriptor_description",
 						"_UI_InboundEndpoint_transportJMSMessageSelector_feature", "_UI_InboundEndpoint_type"),
 				EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_MESSAGE_SELECTOR, true, false, false,
-				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4064,7 +4100,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -4172,7 +4208,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_PropertyDescriptor_description",
 						"_UI_InboundEndpoint_transportJMSReceiveTimeout_feature", "_UI_InboundEndpoint_type"),
 				EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_RECEIVE_TIMEOUT, true, false, false,
-				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4188,7 +4224,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				getString("_UI_InboundEndpoint_transportJMSContentType_feature"),
 				getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJMSContentType_feature",
 						"_UI_InboundEndpoint_type"), EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_CONTENT_TYPE,
-				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters", null));
+				true, false, false, ItemPropertyDescriptor.GENERIC_VALUE_IMAGE, "Parameters(Advanced)", null));
 	}
 
 	/**
@@ -4209,7 +4245,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -4231,7 +4267,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -4253,7 +4289,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
 				 null));
 	}
 
@@ -4275,7 +4311,29 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 false,
 				 false,
 				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
-				 "Parameters",
+				 "Parameters(Advanced)",
+				 null));
+	}
+
+	/**
+	 * This adds a property descriptor for the Transport JMS Broker Type feature.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	protected void addTransportJMSBrokerTypePropertyDescriptor(Object object) {
+		itemPropertyDescriptors.add
+			(createItemPropertyDescriptor
+				(((ComposeableAdapterFactory)adapterFactory).getRootAdapterFactory(),
+				 getResourceLocator(),
+				 getString("_UI_InboundEndpoint_transportJMSBrokerType_feature"),
+				 getString("_UI_PropertyDescriptor_description", "_UI_InboundEndpoint_transportJMSBrokerType_feature", "_UI_InboundEndpoint_type"),
+				 EsbPackage.Literals.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE,
+				 true,
+				 false,
+				 false,
+				 ItemPropertyDescriptor.GENERIC_VALUE_IMAGE,
+				 null,
 				 null));
 	}
 
@@ -4757,6 +4815,7 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_REPLY_DESTINATION:
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_PUB_SUB_NO_LOCAL:
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME:
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE:
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY:
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME:
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_PORT:
@@ -4954,4 +5013,67 @@ public class InboundEndpointItemProvider extends EsbElementItemProvider {
 				 EsbFactory.eINSTANCE.createRegistryKeyProperty()));
 	}
 
+	/**
+	 * This updates the value of JavaNamingFactoryInitial to the new value
+	 */
+	private void updateJavaNamingFactoryInitialProperty(final InboundEndpoint inboundEndpoint, final String newValue) {
+		
+		TransactionalEditingDomain domain1 = TransactionUtil.getEditingDomain(inboundEndpoint);
+	    domain1.getCommandStack().execute(new RecordingCommand(domain1) {
+ 	        @Override
+	        protected void doExecute() {
+	        	if(! inboundEndpoint.getJavaNamingFactoryInitial().equals(newValue)) {
+	        	inboundEndpoint.setJavaNamingFactoryInitial(newValue);
+	        	}
+	        }
+	    });
+	}
+	
+	/**
+	 * This updates the value of JavaNamingProviderUrl to the new value 
+	 */
+	private void updateJavaNamingProviderUrlProperty(final InboundEndpoint inboundEndpoint, final String newValue) {
+		
+		TransactionalEditingDomain domain1 = TransactionUtil.getEditingDomain(inboundEndpoint);
+	    domain1.getCommandStack().execute(new RecordingCommand(domain1) {
+ 	        @Override
+	        protected void doExecute() {
+	        	if(! inboundEndpoint.getJavaNamingProviderUrl().equals(newValue)) {
+	        	inboundEndpoint.setJavaNamingProviderUrl(newValue);
+	        	}
+	        }
+	    });
+	}
+	
+	/**
+	 * This updates the value of TransportJMSDestination to the new value 
+	 */
+	private void updateTransportJMSDestinationProperty(final InboundEndpoint inboundEndpoint,final String newValue) {
+		
+		TransactionalEditingDomain domain1 = TransactionUtil.getEditingDomain(inboundEndpoint);
+	    domain1.getCommandStack().execute(new RecordingCommand(domain1) {
+ 	        @Override
+	        protected void doExecute() {
+	        	if(! inboundEndpoint.getTransportJMSDestination().equals(newValue)) {
+	        	inboundEndpoint.setTransportJMSDestination(newValue);
+	        	}
+	        }
+	    });
+	}
+	
+	/**
+	 * This updates the value of TransportJMSConnectionFactoryJNDIName to the new value 
+	 */
+	private void updateTransportJMSConnectionFactoryJNDINameProperty(final InboundEndpoint inboundEndpoint,final String newValue) {
+		
+		TransactionalEditingDomain domain1 = TransactionUtil.getEditingDomain(inboundEndpoint);
+	    domain1.getCommandStack().execute(new RecordingCommand(domain1) {
+ 	        @Override
+	        protected void doExecute() {
+	        	if(! inboundEndpoint.getTransportJMSConnectionFactoryJNDIName().equals(newValue)) {
+	        	inboundEndpoint.setTransportJMSConnectionFactoryJNDIName(newValue);
+	        	}
+	        }
+	    });
+	}
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.ecore
@@ -2967,7 +2967,7 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSConnectionFactoryJNDIName"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" defaultValueLiteral=""/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSConnectionFactoryType"
-        eType="#//JMSConnectionFactoryType"/>
+        eType="#//JMSConnectionFactoryType" defaultValueLiteral="queue"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSConcurrentConsumers"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSDestination"
@@ -3014,6 +3014,8 @@
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" defaultValueLiteral=""/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSDurableSubscriberName"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportJMSBrokerType"
+        eType="#//JMSBrokerType" defaultValueLiteral="OTHER"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportMQTTConnectionFactory"
         eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString" defaultValueLiteral=""/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="transportMQTTServerHostName"
@@ -3342,6 +3344,11 @@
     <eLiterals name="three" value="3" literal="3"/>
     <eLiterals name="two" value="2" literal="2"/>
     <eLiterals name="one" value="1" literal="1"/>
+  </eClassifiers>
+  <eClassifiers xsi:type="ecore:EEnum" name="JMSBrokerType">
+    <eLiterals name="WSO2_BROKER_PROFILE"/>
+    <eLiterals name="ActiveMQ" value="1"/>
+    <eLiterals name="OTHER" value="2"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EEnum" name="WSClientSideBroadcastLevel">
     <eLiterals name="zero" literal="0"/>

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.genmodel
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/model/esb.genmodel
@@ -742,6 +742,11 @@
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//JMSCacheLevel/two"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//JMSCacheLevel/one"/>
     </genEnums>
+    <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//JMSBrokerType">
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//JMSBrokerType/WSO2_BROKER_PROFILE"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//JMSBrokerType/ActiveMQ"/>
+      <genEnumLiterals ecoreEnumLiteral="esb.ecore#//JMSBrokerType/OTHER"/>
+    </genEnums>
     <genEnums typeSafeEnumCompatible="false" ecoreEnum="esb.ecore#//WSClientSideBroadcastLevel">
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//WSClientSideBroadcastLevel/zero"/>
       <genEnumLiterals ecoreEnumLiteral="esb.ecore#//WSClientSideBroadcastLevel/one"/>
@@ -2423,6 +2428,7 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJMSReplyDestination"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJMSPubSubNoLocal"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJMSDurableSubscriberName"/>
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportJMSBrokerType"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportMQTTConnectionFactory"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportMQTTServerHostName"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute esb.ecore#//InboundEndpoint/transportMQTTServerPort"/>

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/EsbPackage.java
@@ -23870,13 +23870,22 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	int INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME = ESB_ELEMENT_FEATURE_COUNT + 72;
 
 	/**
+	 * The feature id for the '<em><b>Transport JMS Broker Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE = ESB_ELEMENT_FEATURE_COUNT + 73;
+
+	/**
 	 * The feature id for the '<em><b>Transport MQTT Connection Factory</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY = ESB_ELEMENT_FEATURE_COUNT + 73;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY = ESB_ELEMENT_FEATURE_COUNT + 74;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Server Host Name</b></em>' attribute.
@@ -23885,7 +23894,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME = ESB_ELEMENT_FEATURE_COUNT + 74;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME = ESB_ELEMENT_FEATURE_COUNT + 75;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Server Port</b></em>' attribute.
@@ -23894,7 +23903,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_PORT = ESB_ELEMENT_FEATURE_COUNT + 75;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_PORT = ESB_ELEMENT_FEATURE_COUNT + 76;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Topic Name</b></em>' attribute.
@@ -23903,7 +23912,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_TOPIC_NAME = ESB_ELEMENT_FEATURE_COUNT + 76;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_TOPIC_NAME = ESB_ELEMENT_FEATURE_COUNT + 77;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Subscription QOS</b></em>' attribute.
@@ -23912,7 +23921,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_QOS = ESB_ELEMENT_FEATURE_COUNT + 77;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_QOS = ESB_ELEMENT_FEATURE_COUNT + 78;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Session Clean</b></em>' attribute.
@@ -23921,7 +23930,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SESSION_CLEAN = ESB_ELEMENT_FEATURE_COUNT + 78;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SESSION_CLEAN = ESB_ELEMENT_FEATURE_COUNT + 79;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Enable</b></em>' attribute.
@@ -23930,7 +23939,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_ENABLE = ESB_ELEMENT_FEATURE_COUNT + 79;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_ENABLE = ESB_ELEMENT_FEATURE_COUNT + 80;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Temporary Store Directory</b></em>' attribute.
@@ -23939,7 +23948,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_TEMPORARY_STORE_DIRECTORY = ESB_ELEMENT_FEATURE_COUNT + 80;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_TEMPORARY_STORE_DIRECTORY = ESB_ELEMENT_FEATURE_COUNT + 81;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Subscription Username</b></em>' attribute.
@@ -23948,7 +23957,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_USERNAME = ESB_ELEMENT_FEATURE_COUNT + 81;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_USERNAME = ESB_ELEMENT_FEATURE_COUNT + 82;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Subscription Password</b></em>' attribute.
@@ -23957,7 +23966,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 82;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SUBSCRIPTION_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 83;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Client Id</b></em>' attribute.
@@ -23966,7 +23975,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_CLIENT_ID = ESB_ELEMENT_FEATURE_COUNT + 83;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_CLIENT_ID = ESB_ELEMENT_FEATURE_COUNT + 84;
 
 	/**
 	 * The feature id for the '<em><b>Truststore</b></em>' attribute.
@@ -23975,7 +23984,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRUSTSTORE = ESB_ELEMENT_FEATURE_COUNT + 84;
+	int INBOUND_ENDPOINT__TRUSTSTORE = ESB_ELEMENT_FEATURE_COUNT + 85;
 
 	/**
 	 * The feature id for the '<em><b>Keystore</b></em>' attribute.
@@ -23984,7 +23993,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__KEYSTORE = ESB_ELEMENT_FEATURE_COUNT + 85;
+	int INBOUND_ENDPOINT__KEYSTORE = ESB_ELEMENT_FEATURE_COUNT + 86;
 
 	/**
 	 * The feature id for the '<em><b>Ssl Verify Client</b></em>' attribute.
@@ -23993,7 +24002,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SSL_VERIFY_CLIENT = ESB_ELEMENT_FEATURE_COUNT + 86;
+	int INBOUND_ENDPOINT__SSL_VERIFY_CLIENT = ESB_ELEMENT_FEATURE_COUNT + 87;
 
 	/**
 	 * The feature id for the '<em><b>Ssl Protocol</b></em>' attribute.
@@ -24002,7 +24011,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SSL_PROTOCOL = ESB_ELEMENT_FEATURE_COUNT + 87;
+	int INBOUND_ENDPOINT__SSL_PROTOCOL = ESB_ELEMENT_FEATURE_COUNT + 88;
 
 	/**
 	 * The feature id for the '<em><b>Https Protocols</b></em>' attribute.
@@ -24011,7 +24020,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__HTTPS_PROTOCOLS = ESB_ELEMENT_FEATURE_COUNT + 88;
+	int INBOUND_ENDPOINT__HTTPS_PROTOCOLS = ESB_ELEMENT_FEATURE_COUNT + 89;
 
 	/**
 	 * The feature id for the '<em><b>Certificate Revocation Verifier</b></em>' attribute.
@@ -24020,7 +24029,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CERTIFICATE_REVOCATION_VERIFIER = ESB_ELEMENT_FEATURE_COUNT + 89;
+	int INBOUND_ENDPOINT__CERTIFICATE_REVOCATION_VERIFIER = ESB_ELEMENT_FEATURE_COUNT + 90;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Port</b></em>' attribute.
@@ -24029,7 +24038,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_PORT = ESB_ELEMENT_FEATURE_COUNT + 90;
+	int INBOUND_ENDPOINT__INBOUND_HL7_PORT = ESB_ELEMENT_FEATURE_COUNT + 91;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Auto Ack</b></em>' attribute.
@@ -24038,7 +24047,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_AUTO_ACK = ESB_ELEMENT_FEATURE_COUNT + 91;
+	int INBOUND_ENDPOINT__INBOUND_HL7_AUTO_ACK = ESB_ELEMENT_FEATURE_COUNT + 92;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Message Pre Processor</b></em>' attribute.
@@ -24047,7 +24056,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_MESSAGE_PRE_PROCESSOR = ESB_ELEMENT_FEATURE_COUNT + 92;
+	int INBOUND_ENDPOINT__INBOUND_HL7_MESSAGE_PRE_PROCESSOR = ESB_ELEMENT_FEATURE_COUNT + 93;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Char Set</b></em>' attribute.
@@ -24056,7 +24065,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_CHAR_SET = ESB_ELEMENT_FEATURE_COUNT + 93;
+	int INBOUND_ENDPOINT__INBOUND_HL7_CHAR_SET = ESB_ELEMENT_FEATURE_COUNT + 94;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Time Out</b></em>' attribute.
@@ -24065,7 +24074,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_TIME_OUT = ESB_ELEMENT_FEATURE_COUNT + 94;
+	int INBOUND_ENDPOINT__INBOUND_HL7_TIME_OUT = ESB_ELEMENT_FEATURE_COUNT + 95;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Validate Message</b></em>' attribute.
@@ -24074,7 +24083,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_VALIDATE_MESSAGE = ESB_ELEMENT_FEATURE_COUNT + 95;
+	int INBOUND_ENDPOINT__INBOUND_HL7_VALIDATE_MESSAGE = ESB_ELEMENT_FEATURE_COUNT + 96;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Build Invalid Messages</b></em>' attribute.
@@ -24083,7 +24092,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_BUILD_INVALID_MESSAGES = ESB_ELEMENT_FEATURE_COUNT + 96;
+	int INBOUND_ENDPOINT__INBOUND_HL7_BUILD_INVALID_MESSAGES = ESB_ELEMENT_FEATURE_COUNT + 97;
 
 	/**
 	 * The feature id for the '<em><b>Inbound HL7 Pass Through Invalid Messages</b></em>' attribute.
@@ -24092,7 +24101,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_HL7_PASS_THROUGH_INVALID_MESSAGES = ESB_ELEMENT_FEATURE_COUNT + 97;
+	int INBOUND_ENDPOINT__INBOUND_HL7_PASS_THROUGH_INVALID_MESSAGES = ESB_ELEMENT_FEATURE_COUNT + 98;
 
 	/**
 	 * The feature id for the '<em><b>Zookeeper Connect</b></em>' attribute.
@@ -24101,7 +24110,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__ZOOKEEPER_CONNECT = ESB_ELEMENT_FEATURE_COUNT + 98;
+	int INBOUND_ENDPOINT__ZOOKEEPER_CONNECT = ESB_ELEMENT_FEATURE_COUNT + 99;
 
 	/**
 	 * The feature id for the '<em><b>Group Id</b></em>' attribute.
@@ -24110,7 +24119,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__GROUP_ID = ESB_ELEMENT_FEATURE_COUNT + 99;
+	int INBOUND_ENDPOINT__GROUP_ID = ESB_ELEMENT_FEATURE_COUNT + 100;
 
 	/**
 	 * The feature id for the '<em><b>Content Type</b></em>' attribute.
@@ -24119,7 +24128,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 100;
+	int INBOUND_ENDPOINT__CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 101;
 
 	/**
 	 * The feature id for the '<em><b>Consumer Type</b></em>' attribute.
@@ -24128,7 +24137,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CONSUMER_TYPE = ESB_ELEMENT_FEATURE_COUNT + 101;
+	int INBOUND_ENDPOINT__CONSUMER_TYPE = ESB_ELEMENT_FEATURE_COUNT + 102;
 
 	/**
 	 * The feature id for the '<em><b>Topics Or Topic Filter</b></em>' attribute.
@@ -24137,7 +24146,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TOPICS_OR_TOPIC_FILTER = ESB_ELEMENT_FEATURE_COUNT + 102;
+	int INBOUND_ENDPOINT__TOPICS_OR_TOPIC_FILTER = ESB_ELEMENT_FEATURE_COUNT + 103;
 
 	/**
 	 * The feature id for the '<em><b>Topics Name</b></em>' attribute.
@@ -24146,7 +24155,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TOPICS_NAME = ESB_ELEMENT_FEATURE_COUNT + 103;
+	int INBOUND_ENDPOINT__TOPICS_NAME = ESB_ELEMENT_FEATURE_COUNT + 104;
 
 	/**
 	 * The feature id for the '<em><b>Topic Filter From</b></em>' attribute.
@@ -24155,7 +24164,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TOPIC_FILTER_FROM = ESB_ELEMENT_FEATURE_COUNT + 104;
+	int INBOUND_ENDPOINT__TOPIC_FILTER_FROM = ESB_ELEMENT_FEATURE_COUNT + 105;
 
 	/**
 	 * The feature id for the '<em><b>Topic Filter Name</b></em>' attribute.
@@ -24164,7 +24173,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TOPIC_FILTER_NAME = ESB_ELEMENT_FEATURE_COUNT + 105;
+	int INBOUND_ENDPOINT__TOPIC_FILTER_NAME = ESB_ELEMENT_FEATURE_COUNT + 106;
 
 	/**
 	 * The feature id for the '<em><b>Simple Consumer Topic</b></em>' attribute.
@@ -24173,7 +24182,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_TOPIC = ESB_ELEMENT_FEATURE_COUNT + 106;
+	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_TOPIC = ESB_ELEMENT_FEATURE_COUNT + 107;
 
 	/**
 	 * The feature id for the '<em><b>Simple Consumer Brokers</b></em>' attribute.
@@ -24182,7 +24191,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_BROKERS = ESB_ELEMENT_FEATURE_COUNT + 107;
+	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_BROKERS = ESB_ELEMENT_FEATURE_COUNT + 108;
 
 	/**
 	 * The feature id for the '<em><b>Simple Consumer Port</b></em>' attribute.
@@ -24191,7 +24200,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_PORT = ESB_ELEMENT_FEATURE_COUNT + 108;
+	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_PORT = ESB_ELEMENT_FEATURE_COUNT + 109;
 
 	/**
 	 * The feature id for the '<em><b>Simple Consumer Partition</b></em>' attribute.
@@ -24200,7 +24209,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_PARTITION = ESB_ELEMENT_FEATURE_COUNT + 109;
+	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_PARTITION = ESB_ELEMENT_FEATURE_COUNT + 110;
 
 	/**
 	 * The feature id for the '<em><b>Simple Consumer Max Messages To Read</b></em>' attribute.
@@ -24209,7 +24218,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_MAX_MESSAGES_TO_READ = ESB_ELEMENT_FEATURE_COUNT + 110;
+	int INBOUND_ENDPOINT__SIMPLE_CONSUMER_MAX_MESSAGES_TO_READ = ESB_ELEMENT_FEATURE_COUNT + 111;
 
 	/**
 	 * The feature id for the '<em><b>Thread Count</b></em>' attribute.
@@ -24218,7 +24227,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__THREAD_COUNT = ESB_ELEMENT_FEATURE_COUNT + 111;
+	int INBOUND_ENDPOINT__THREAD_COUNT = ESB_ELEMENT_FEATURE_COUNT + 112;
 
 	/**
 	 * The feature id for the '<em><b>Consumer Id</b></em>' attribute.
@@ -24227,7 +24236,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CONSUMER_ID = ESB_ELEMENT_FEATURE_COUNT + 112;
+	int INBOUND_ENDPOINT__CONSUMER_ID = ESB_ELEMENT_FEATURE_COUNT + 113;
 
 	/**
 	 * The feature id for the '<em><b>Socket Timeout Ms</b></em>' attribute.
@@ -24236,7 +24245,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SOCKET_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 113;
+	int INBOUND_ENDPOINT__SOCKET_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 114;
 
 	/**
 	 * The feature id for the '<em><b>Socket Receive Buffer Bytes</b></em>' attribute.
@@ -24245,7 +24254,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SOCKET_RECEIVE_BUFFER_BYTES = ESB_ELEMENT_FEATURE_COUNT + 114;
+	int INBOUND_ENDPOINT__SOCKET_RECEIVE_BUFFER_BYTES = ESB_ELEMENT_FEATURE_COUNT + 115;
 
 	/**
 	 * The feature id for the '<em><b>Fetch Message Max Bytes</b></em>' attribute.
@@ -24254,7 +24263,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__FETCH_MESSAGE_MAX_BYTES = ESB_ELEMENT_FEATURE_COUNT + 115;
+	int INBOUND_ENDPOINT__FETCH_MESSAGE_MAX_BYTES = ESB_ELEMENT_FEATURE_COUNT + 116;
 
 	/**
 	 * The feature id for the '<em><b>Num Consumer Fetches</b></em>' attribute.
@@ -24263,7 +24272,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__NUM_CONSUMER_FETCHES = ESB_ELEMENT_FEATURE_COUNT + 116;
+	int INBOUND_ENDPOINT__NUM_CONSUMER_FETCHES = ESB_ELEMENT_FEATURE_COUNT + 117;
 
 	/**
 	 * The feature id for the '<em><b>Auto Commit Enable</b></em>' attribute.
@@ -24272,7 +24281,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__AUTO_COMMIT_ENABLE = ESB_ELEMENT_FEATURE_COUNT + 117;
+	int INBOUND_ENDPOINT__AUTO_COMMIT_ENABLE = ESB_ELEMENT_FEATURE_COUNT + 118;
 
 	/**
 	 * The feature id for the '<em><b>Auto Commit Interval Ms</b></em>' attribute.
@@ -24281,7 +24290,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__AUTO_COMMIT_INTERVAL_MS = ESB_ELEMENT_FEATURE_COUNT + 118;
+	int INBOUND_ENDPOINT__AUTO_COMMIT_INTERVAL_MS = ESB_ELEMENT_FEATURE_COUNT + 119;
 
 	/**
 	 * The feature id for the '<em><b>Queued Max Message Chunks</b></em>' attribute.
@@ -24290,7 +24299,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__QUEUED_MAX_MESSAGE_CHUNKS = ESB_ELEMENT_FEATURE_COUNT + 119;
+	int INBOUND_ENDPOINT__QUEUED_MAX_MESSAGE_CHUNKS = ESB_ELEMENT_FEATURE_COUNT + 120;
 
 	/**
 	 * The feature id for the '<em><b>Rebalance Max Retries</b></em>' attribute.
@@ -24299,7 +24308,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__REBALANCE_MAX_RETRIES = ESB_ELEMENT_FEATURE_COUNT + 120;
+	int INBOUND_ENDPOINT__REBALANCE_MAX_RETRIES = ESB_ELEMENT_FEATURE_COUNT + 121;
 
 	/**
 	 * The feature id for the '<em><b>Fetch Min Bytes</b></em>' attribute.
@@ -24308,7 +24317,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__FETCH_MIN_BYTES = ESB_ELEMENT_FEATURE_COUNT + 121;
+	int INBOUND_ENDPOINT__FETCH_MIN_BYTES = ESB_ELEMENT_FEATURE_COUNT + 122;
 
 	/**
 	 * The feature id for the '<em><b>Fetch Wait Max Ms</b></em>' attribute.
@@ -24317,7 +24326,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__FETCH_WAIT_MAX_MS = ESB_ELEMENT_FEATURE_COUNT + 122;
+	int INBOUND_ENDPOINT__FETCH_WAIT_MAX_MS = ESB_ELEMENT_FEATURE_COUNT + 123;
 
 	/**
 	 * The feature id for the '<em><b>Rebalance Backoff Ms</b></em>' attribute.
@@ -24326,7 +24335,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__REBALANCE_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 123;
+	int INBOUND_ENDPOINT__REBALANCE_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 124;
 
 	/**
 	 * The feature id for the '<em><b>Refresh Leader Backoff Ms</b></em>' attribute.
@@ -24335,7 +24344,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__REFRESH_LEADER_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 124;
+	int INBOUND_ENDPOINT__REFRESH_LEADER_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 125;
 
 	/**
 	 * The feature id for the '<em><b>Auto Offset Reset</b></em>' attribute.
@@ -24344,7 +24353,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__AUTO_OFFSET_RESET = ESB_ELEMENT_FEATURE_COUNT + 125;
+	int INBOUND_ENDPOINT__AUTO_OFFSET_RESET = ESB_ELEMENT_FEATURE_COUNT + 126;
 
 	/**
 	 * The feature id for the '<em><b>Consumer Timeout Ms</b></em>' attribute.
@@ -24353,7 +24362,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CONSUMER_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 126;
+	int INBOUND_ENDPOINT__CONSUMER_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 127;
 
 	/**
 	 * The feature id for the '<em><b>Exclude Internal Topics</b></em>' attribute.
@@ -24362,7 +24371,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__EXCLUDE_INTERNAL_TOPICS = ESB_ELEMENT_FEATURE_COUNT + 127;
+	int INBOUND_ENDPOINT__EXCLUDE_INTERNAL_TOPICS = ESB_ELEMENT_FEATURE_COUNT + 128;
 
 	/**
 	 * The feature id for the '<em><b>Partition Assignment Strategy</b></em>' attribute.
@@ -24371,7 +24380,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__PARTITION_ASSIGNMENT_STRATEGY = ESB_ELEMENT_FEATURE_COUNT + 128;
+	int INBOUND_ENDPOINT__PARTITION_ASSIGNMENT_STRATEGY = ESB_ELEMENT_FEATURE_COUNT + 129;
 
 	/**
 	 * The feature id for the '<em><b>Client Id</b></em>' attribute.
@@ -24380,7 +24389,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__CLIENT_ID = ESB_ELEMENT_FEATURE_COUNT + 129;
+	int INBOUND_ENDPOINT__CLIENT_ID = ESB_ELEMENT_FEATURE_COUNT + 130;
 
 	/**
 	 * The feature id for the '<em><b>Zookeeper Session Timeout Ms</b></em>' attribute.
@@ -24389,7 +24398,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__ZOOKEEPER_SESSION_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 130;
+	int INBOUND_ENDPOINT__ZOOKEEPER_SESSION_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 131;
 
 	/**
 	 * The feature id for the '<em><b>Zookeeper Connection Timeout Ms</b></em>' attribute.
@@ -24398,7 +24407,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__ZOOKEEPER_CONNECTION_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 131;
+	int INBOUND_ENDPOINT__ZOOKEEPER_CONNECTION_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 132;
 
 	/**
 	 * The feature id for the '<em><b>Zookeeper Sync Time Ms</b></em>' attribute.
@@ -24407,7 +24416,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__ZOOKEEPER_SYNC_TIME_MS = ESB_ELEMENT_FEATURE_COUNT + 132;
+	int INBOUND_ENDPOINT__ZOOKEEPER_SYNC_TIME_MS = ESB_ELEMENT_FEATURE_COUNT + 133;
 
 	/**
 	 * The feature id for the '<em><b>Offsets Storage</b></em>' attribute.
@@ -24416,7 +24425,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__OFFSETS_STORAGE = ESB_ELEMENT_FEATURE_COUNT + 133;
+	int INBOUND_ENDPOINT__OFFSETS_STORAGE = ESB_ELEMENT_FEATURE_COUNT + 134;
 
 	/**
 	 * The feature id for the '<em><b>Offsets Channel Backoff Ms</b></em>' attribute.
@@ -24425,7 +24434,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__OFFSETS_CHANNEL_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 134;
+	int INBOUND_ENDPOINT__OFFSETS_CHANNEL_BACKOFF_MS = ESB_ELEMENT_FEATURE_COUNT + 135;
 
 	/**
 	 * The feature id for the '<em><b>Offsets Channel Socket Timeout Ms</b></em>' attribute.
@@ -24434,7 +24443,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__OFFSETS_CHANNEL_SOCKET_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 135;
+	int INBOUND_ENDPOINT__OFFSETS_CHANNEL_SOCKET_TIMEOUT_MS = ESB_ELEMENT_FEATURE_COUNT + 136;
 
 	/**
 	 * The feature id for the '<em><b>Offsets Commit Max Retries</b></em>' attribute.
@@ -24443,7 +24452,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__OFFSETS_COMMIT_MAX_RETRIES = ESB_ELEMENT_FEATURE_COUNT + 136;
+	int INBOUND_ENDPOINT__OFFSETS_COMMIT_MAX_RETRIES = ESB_ELEMENT_FEATURE_COUNT + 137;
 
 	/**
 	 * The feature id for the '<em><b>Dual Commit Enabled</b></em>' attribute.
@@ -24452,7 +24461,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__DUAL_COMMIT_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 137;
+	int INBOUND_ENDPOINT__DUAL_COMMIT_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 138;
 
 	/**
 	 * The feature id for the '<em><b>Inbound Cxf Rm Host</b></em>' attribute.
@@ -24461,7 +24470,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_CXF_RM_HOST = ESB_ELEMENT_FEATURE_COUNT + 138;
+	int INBOUND_ENDPOINT__INBOUND_CXF_RM_HOST = ESB_ELEMENT_FEATURE_COUNT + 139;
 
 	/**
 	 * The feature id for the '<em><b>Inbound Cxf Rm Port</b></em>' attribute.
@@ -24470,7 +24479,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_CXF_RM_PORT = ESB_ELEMENT_FEATURE_COUNT + 139;
+	int INBOUND_ENDPOINT__INBOUND_CXF_RM_PORT = ESB_ELEMENT_FEATURE_COUNT + 140;
 
 	/**
 	 * The feature id for the '<em><b>Inbound Cxf Rm Config File</b></em>' attribute.
@@ -24479,7 +24488,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__INBOUND_CXF_RM_CONFIG_FILE = ESB_ELEMENT_FEATURE_COUNT + 140;
+	int INBOUND_ENDPOINT__INBOUND_CXF_RM_CONFIG_FILE = ESB_ELEMENT_FEATURE_COUNT + 141;
 
 	/**
 	 * The feature id for the '<em><b>Enable SSL</b></em>' attribute.
@@ -24488,7 +24497,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__ENABLE_SSL = ESB_ELEMENT_FEATURE_COUNT + 141;
+	int INBOUND_ENDPOINT__ENABLE_SSL = ESB_ELEMENT_FEATURE_COUNT + 142;
 
 	/**
 	 * The feature id for the '<em><b>Service Parameters</b></em>' containment reference list.
@@ -24497,7 +24506,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SERVICE_PARAMETERS = ESB_ELEMENT_FEATURE_COUNT + 142;
+	int INBOUND_ENDPOINT__SERVICE_PARAMETERS = ESB_ELEMENT_FEATURE_COUNT + 143;
 
 	/**
 	 * The feature id for the '<em><b>Suspend</b></em>' attribute.
@@ -24506,7 +24515,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__SUSPEND = ESB_ELEMENT_FEATURE_COUNT + 143;
+	int INBOUND_ENDPOINT__SUSPEND = ESB_ELEMENT_FEATURE_COUNT + 144;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Factory</b></em>' attribute.
@@ -24515,7 +24524,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_FACTORY = ESB_ELEMENT_FEATURE_COUNT + 144;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_FACTORY = ESB_ELEMENT_FEATURE_COUNT + 145;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server Host Name</b></em>' attribute.
@@ -24524,7 +24533,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_HOST_NAME = ESB_ELEMENT_FEATURE_COUNT + 145;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_HOST_NAME = ESB_ELEMENT_FEATURE_COUNT + 146;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server Port</b></em>' attribute.
@@ -24533,7 +24542,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_PORT = ESB_ELEMENT_FEATURE_COUNT + 146;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_PORT = ESB_ELEMENT_FEATURE_COUNT + 147;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server User Name</b></em>' attribute.
@@ -24542,7 +24551,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_USER_NAME = ESB_ELEMENT_FEATURE_COUNT + 147;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_USER_NAME = ESB_ELEMENT_FEATURE_COUNT + 148;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server Password</b></em>' attribute.
@@ -24551,7 +24560,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 148;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 149;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Name</b></em>' attribute.
@@ -24560,7 +24569,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_NAME = ESB_ELEMENT_FEATURE_COUNT + 149;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_NAME = ESB_ELEMENT_FEATURE_COUNT + 150;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Exchange Name</b></em>' attribute.
@@ -24569,7 +24578,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_NAME = ESB_ELEMENT_FEATURE_COUNT + 150;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_NAME = ESB_ELEMENT_FEATURE_COUNT + 151;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Durable</b></em>' attribute.
@@ -24578,7 +24587,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_DURABLE = ESB_ELEMENT_FEATURE_COUNT + 151;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_DURABLE = ESB_ELEMENT_FEATURE_COUNT + 152;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Exclusive</b></em>' attribute.
@@ -24587,7 +24596,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_EXCLUSIVE = ESB_ELEMENT_FEATURE_COUNT + 152;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_EXCLUSIVE = ESB_ELEMENT_FEATURE_COUNT + 153;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Auto Delete</b></em>' attribute.
@@ -24596,7 +24605,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_AUTO_DELETE = ESB_ELEMENT_FEATURE_COUNT + 153;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_AUTO_DELETE = ESB_ELEMENT_FEATURE_COUNT + 154;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Auto Ack</b></em>' attribute.
@@ -24605,7 +24614,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_AUTO_ACK = ESB_ELEMENT_FEATURE_COUNT + 154;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_AUTO_ACK = ESB_ELEMENT_FEATURE_COUNT + 155;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Routing Key</b></em>' attribute.
@@ -24614,7 +24623,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_ROUTING_KEY = ESB_ELEMENT_FEATURE_COUNT + 155;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_ROUTING_KEY = ESB_ELEMENT_FEATURE_COUNT + 156;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Queue Delivery Mode</b></em>' attribute.
@@ -24623,7 +24632,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_DELIVERY_MODE = ESB_ELEMENT_FEATURE_COUNT + 156;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_QUEUE_DELIVERY_MODE = ESB_ELEMENT_FEATURE_COUNT + 157;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Exchange Type</b></em>' attribute.
@@ -24632,7 +24641,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 157;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 158;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Exchange Durable</b></em>' attribute.
@@ -24641,7 +24650,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_DURABLE = ESB_ELEMENT_FEATURE_COUNT + 158;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_DURABLE = ESB_ELEMENT_FEATURE_COUNT + 159;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Exchange Auto Delete</b></em>' attribute.
@@ -24650,7 +24659,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_AUTO_DELETE = ESB_ELEMENT_FEATURE_COUNT + 159;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_EXCHANGE_AUTO_DELETE = ESB_ELEMENT_FEATURE_COUNT + 160;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server Virtual Host</b></em>' attribute.
@@ -24659,7 +24668,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_VIRTUAL_HOST = ESB_ELEMENT_FEATURE_COUNT + 160;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_VIRTUAL_HOST = ESB_ELEMENT_FEATURE_COUNT + 161;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Factory Heartbeat</b></em>' attribute.
@@ -24668,7 +24677,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_FACTORY_HEARTBEAT = ESB_ELEMENT_FEATURE_COUNT + 161;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_FACTORY_HEARTBEAT = ESB_ELEMENT_FEATURE_COUNT + 162;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Enabled</b></em>' attribute.
@@ -24677,7 +24686,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 162;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 163;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Keystore Location</b></em>' attribute.
@@ -24686,7 +24695,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 163;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 164;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Keystore Type</b></em>' attribute.
@@ -24695,7 +24704,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 164;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 165;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Keystore Password</b></em>' attribute.
@@ -24704,7 +24713,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 165;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_KEYSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 166;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Truststore Location</b></em>' attribute.
@@ -24713,7 +24722,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 166;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 167;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Truststore Type</b></em>' attribute.
@@ -24722,7 +24731,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 167;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 168;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Truststore Password</b></em>' attribute.
@@ -24731,7 +24740,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 168;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_TRUSTSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 169;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Ssl Version</b></em>' attribute.
@@ -24740,7 +24749,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_VERSION = ESB_ELEMENT_FEATURE_COUNT + 169;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_SSL_VERSION = ESB_ELEMENT_FEATURE_COUNT + 170;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Message Content Type</b></em>' attribute.
@@ -24749,7 +24758,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_MESSAGE_CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 170;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_MESSAGE_CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 171;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Retry Count</b></em>' attribute.
@@ -24758,7 +24767,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_RETRY_COUNT = ESB_ELEMENT_FEATURE_COUNT + 171;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_RETRY_COUNT = ESB_ELEMENT_FEATURE_COUNT + 172;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Connection Retry Interval</b></em>' attribute.
@@ -24767,7 +24776,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_RETRY_INTERVAL = ESB_ELEMENT_FEATURE_COUNT + 172;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONNECTION_RETRY_INTERVAL = ESB_ELEMENT_FEATURE_COUNT + 173;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Server Retry Interval</b></em>' attribute.
@@ -24776,7 +24785,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_RETRY_INTERVAL = ESB_ELEMENT_FEATURE_COUNT + 173;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_SERVER_RETRY_INTERVAL = ESB_ELEMENT_FEATURE_COUNT + 174;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Consumer Qos Key</b></em>' containment reference.
@@ -24785,7 +24794,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS_KEY = ESB_ELEMENT_FEATURE_COUNT + 174;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS_KEY = ESB_ELEMENT_FEATURE_COUNT + 175;
 
 	/**
 	 * The feature id for the '<em><b>Ws Inbound Port</b></em>' attribute.
@@ -24794,7 +24803,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_INBOUND_PORT = ESB_ELEMENT_FEATURE_COUNT + 175;
+	int INBOUND_ENDPOINT__WS_INBOUND_PORT = ESB_ELEMENT_FEATURE_COUNT + 176;
 
 	/**
 	 * The feature id for the '<em><b>Ws Client Side Broadcast Level</b></em>' attribute.
@@ -24803,7 +24812,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_CLIENT_SIDE_BROADCAST_LEVEL = ESB_ELEMENT_FEATURE_COUNT + 176;
+	int INBOUND_ENDPOINT__WS_CLIENT_SIDE_BROADCAST_LEVEL = ESB_ELEMENT_FEATURE_COUNT + 177;
 
 	/**
 	 * The feature id for the '<em><b>Ws Outflow Dispatch Sequence</b></em>' attribute.
@@ -24812,7 +24821,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_OUTFLOW_DISPATCH_SEQUENCE = ESB_ELEMENT_FEATURE_COUNT + 177;
+	int INBOUND_ENDPOINT__WS_OUTFLOW_DISPATCH_SEQUENCE = ESB_ELEMENT_FEATURE_COUNT + 178;
 
 	/**
 	 * The feature id for the '<em><b>Ws Outflow Dispatch Fault Sequence</b></em>' attribute.
@@ -24821,7 +24830,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_OUTFLOW_DISPATCH_FAULT_SEQUENCE = ESB_ELEMENT_FEATURE_COUNT + 178;
+	int INBOUND_ENDPOINT__WS_OUTFLOW_DISPATCH_FAULT_SEQUENCE = ESB_ELEMENT_FEATURE_COUNT + 179;
 
 	/**
 	 * The feature id for the '<em><b>Ws Boss Thread Pool Size</b></em>' attribute.
@@ -24830,7 +24839,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_BOSS_THREAD_POOL_SIZE = ESB_ELEMENT_FEATURE_COUNT + 179;
+	int INBOUND_ENDPOINT__WS_BOSS_THREAD_POOL_SIZE = ESB_ELEMENT_FEATURE_COUNT + 180;
 
 	/**
 	 * The feature id for the '<em><b>Ws Worker Thread Pool Size</b></em>' attribute.
@@ -24839,7 +24848,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_WORKER_THREAD_POOL_SIZE = ESB_ELEMENT_FEATURE_COUNT + 180;
+	int INBOUND_ENDPOINT__WS_WORKER_THREAD_POOL_SIZE = ESB_ELEMENT_FEATURE_COUNT + 181;
 
 	/**
 	 * The feature id for the '<em><b>Ws Subprotocol Handler Class</b></em>' attribute.
@@ -24848,7 +24857,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_SUBPROTOCOL_HANDLER_CLASS = ESB_ELEMENT_FEATURE_COUNT + 181;
+	int INBOUND_ENDPOINT__WS_SUBPROTOCOL_HANDLER_CLASS = ESB_ELEMENT_FEATURE_COUNT + 182;
 
 	/**
 	 * The feature id for the '<em><b>Ws Pipeline Handler Class</b></em>' attribute.
@@ -24857,7 +24866,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_PIPELINE_HANDLER_CLASS = ESB_ELEMENT_FEATURE_COUNT + 182;
+	int INBOUND_ENDPOINT__WS_PIPELINE_HANDLER_CLASS = ESB_ELEMENT_FEATURE_COUNT + 183;
 
 	/**
 	 * The feature id for the '<em><b>Transport Feed URL</b></em>' attribute.
@@ -24866,7 +24875,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_FEED_URL = ESB_ELEMENT_FEATURE_COUNT + 183;
+	int INBOUND_ENDPOINT__TRANSPORT_FEED_URL = ESB_ELEMENT_FEATURE_COUNT + 184;
 
 	/**
 	 * The feature id for the '<em><b>Transport Feed Type</b></em>' attribute.
@@ -24875,7 +24884,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_FEED_TYPE = ESB_ELEMENT_FEATURE_COUNT + 184;
+	int INBOUND_ENDPOINT__TRANSPORT_FEED_TYPE = ESB_ELEMENT_FEATURE_COUNT + 185;
 
 	/**
 	 * The feature id for the '<em><b>Trace Enabled</b></em>' attribute.
@@ -24884,7 +24893,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRACE_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 185;
+	int INBOUND_ENDPOINT__TRACE_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 186;
 
 	/**
 	 * The feature id for the '<em><b>Statistics Enabled</b></em>' attribute.
@@ -24893,7 +24902,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__STATISTICS_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 186;
+	int INBOUND_ENDPOINT__STATISTICS_ENABLED = ESB_ELEMENT_FEATURE_COUNT + 187;
 
 	/**
 	 * The feature id for the '<em><b>Transport JMS Retries Before Suspension</b></em>' attribute.
@@ -24902,7 +24911,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION = ESB_ELEMENT_FEATURE_COUNT + 187;
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_RETRIES_BEFORE_SUSPENSION = ESB_ELEMENT_FEATURE_COUNT + 188;
 	
 	/**
 	 * The feature id for the '<em><b>Transport JMS Reset Connection On Polling Suspension</b></em>' attribute.
@@ -24911,7 +24920,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_JMS_RESET_CONNECTION_ON_POLLING_SUSPENSION = ESB_ELEMENT_FEATURE_COUNT + 188;
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_RESET_CONNECTION_ON_POLLING_SUSPENSION = ESB_ELEMENT_FEATURE_COUNT + 189;
 
 	/**
 	 * The feature id for the '<em><b>Transport JMS Polling Suspension Period</b></em>' attribute.
@@ -24920,7 +24929,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD = ESB_ELEMENT_FEATURE_COUNT + 189;
+	int INBOUND_ENDPOINT__TRANSPORT_JMS_POLLING_SUSPENSION_PERIOD = ESB_ELEMENT_FEATURE_COUNT + 190;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Keystore Location</b></em>' attribute.
@@ -24929,7 +24938,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 190;	
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 191;	
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Keystore Type</b></em>' attribute.
@@ -24938,7 +24947,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 191;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 192;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Keystore Password</b></em>' attribute.
@@ -24947,7 +24956,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 192;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_KEYSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 193;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Truststore Location</b></em>' attribute.
@@ -24956,7 +24965,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 193;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_LOCATION = ESB_ELEMENT_FEATURE_COUNT + 194;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Truststore Type</b></em>' attribute.
@@ -24965,7 +24974,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 194;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_TYPE = ESB_ELEMENT_FEATURE_COUNT + 195;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Truststore Password</b></em>' attribute.
@@ -24974,7 +24983,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 195;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_TRUSTSTORE_PASSWORD = ESB_ELEMENT_FEATURE_COUNT + 196;
 
 	/**
 	 * The feature id for the '<em><b>Transport MQTT Ssl Version</b></em>' attribute.
@@ -24983,7 +24992,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_VERSION = ESB_ELEMENT_FEATURE_COUNT + 196;
+	int INBOUND_ENDPOINT__TRANSPORT_MQTT_SSL_VERSION = ESB_ELEMENT_FEATURE_COUNT + 197;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Key Store File</b></em>' attribute.
@@ -24992,7 +25001,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_KEY_STORE_FILE = ESB_ELEMENT_FEATURE_COUNT + 197;
+	int INBOUND_ENDPOINT__WSS_SSL_KEY_STORE_FILE = ESB_ELEMENT_FEATURE_COUNT + 198;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Key Store Pass</b></em>' attribute.
@@ -25001,7 +25010,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_KEY_STORE_PASS = ESB_ELEMENT_FEATURE_COUNT + 198;
+	int INBOUND_ENDPOINT__WSS_SSL_KEY_STORE_PASS = ESB_ELEMENT_FEATURE_COUNT + 199;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Trust Store File</b></em>' attribute.
@@ -25010,7 +25019,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_TRUST_STORE_FILE = ESB_ELEMENT_FEATURE_COUNT + 199;
+	int INBOUND_ENDPOINT__WSS_SSL_TRUST_STORE_FILE = ESB_ELEMENT_FEATURE_COUNT + 200;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Trust Store Pass</b></em>' attribute.
@@ -25019,7 +25028,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_TRUST_STORE_PASS = ESB_ELEMENT_FEATURE_COUNT + 200;
+	int INBOUND_ENDPOINT__WSS_SSL_TRUST_STORE_PASS = ESB_ELEMENT_FEATURE_COUNT + 201;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Cert Pass</b></em>' attribute.
@@ -25028,7 +25037,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_CERT_PASS = ESB_ELEMENT_FEATURE_COUNT + 201;
+	int INBOUND_ENDPOINT__WSS_SSL_CERT_PASS = ESB_ELEMENT_FEATURE_COUNT + 202;
 
 	/**
 	 * The feature id for the '<em><b>Ws Default Content Type</b></em>' attribute.
@@ -25037,7 +25046,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_DEFAULT_CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 202;
+	int INBOUND_ENDPOINT__WS_DEFAULT_CONTENT_TYPE = ESB_ELEMENT_FEATURE_COUNT + 203;
 
 	/**
 	 * The feature id for the '<em><b>Ws Shutdown Status Code</b></em>' attribute.
@@ -25046,7 +25055,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_SHUTDOWN_STATUS_CODE = ESB_ELEMENT_FEATURE_COUNT + 203;
+	int INBOUND_ENDPOINT__WS_SHUTDOWN_STATUS_CODE = ESB_ELEMENT_FEATURE_COUNT + 204;
 
 	/**
 	 * The feature id for the '<em><b>Ws Shutdown Status Message</b></em>' attribute.
@@ -25055,7 +25064,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_SHUTDOWN_STATUS_MESSAGE = ESB_ELEMENT_FEATURE_COUNT + 204;
+	int INBOUND_ENDPOINT__WS_SHUTDOWN_STATUS_MESSAGE = ESB_ELEMENT_FEATURE_COUNT + 205;
 
 	/**
 	 * The feature id for the '<em><b>Ws Use Port Offset</b></em>' attribute.
@@ -25064,7 +25073,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WS_USE_PORT_OFFSET = ESB_ELEMENT_FEATURE_COUNT + 205;
+	int INBOUND_ENDPOINT__WS_USE_PORT_OFFSET = ESB_ELEMENT_FEATURE_COUNT + 206;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Protocols</b></em>' attribute.
@@ -25073,7 +25082,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_PROTOCOLS = ESB_ELEMENT_FEATURE_COUNT + 206;
+	int INBOUND_ENDPOINT__WSS_SSL_PROTOCOLS = ESB_ELEMENT_FEATURE_COUNT + 207;
 
 	/**
 	 * The feature id for the '<em><b>Wss Ssl Cipher Suites</b></em>' attribute.
@@ -25082,7 +25091,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__WSS_SSL_CIPHER_SUITES = ESB_ELEMENT_FEATURE_COUNT + 207;
+	int INBOUND_ENDPOINT__WSS_SSL_CIPHER_SUITES = ESB_ELEMENT_FEATURE_COUNT + 208;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Consumer Qos</b></em>' attribute.
@@ -25091,7 +25100,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS = ESB_ELEMENT_FEATURE_COUNT + 208;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS = ESB_ELEMENT_FEATURE_COUNT + 209;
 
 	/**
 	 * The feature id for the '<em><b>Transport Rabbit Mq Consumer Qos Type</b></em>' attribute.
@@ -25100,7 +25109,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS_TYPE = ESB_ELEMENT_FEATURE_COUNT + 209;
+	int INBOUND_ENDPOINT__TRANSPORT_RABBIT_MQ_CONSUMER_QOS_TYPE = ESB_ELEMENT_FEATURE_COUNT + 210;
 
 	/**
 	 * The number of structural features of the '<em>Inbound Endpoint</em>' class.
@@ -25109,7 +25118,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @generated
 	 * @ordered
 	 */
-	int INBOUND_ENDPOINT_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 210;
+	int INBOUND_ENDPOINT_FEATURE_COUNT = ESB_ELEMENT_FEATURE_COUNT + 211;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointParameterImpl <em>Inbound Endpoint Parameter</em>}' class.
@@ -26666,6 +26675,16 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	int JMS_CACHE_LEVEL = 484;
 
 	/**
+	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType <em>JMS Broker Type</em>}' enum.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getJMSBrokerType()
+	 * @generated
+	 */
+	int JMS_BROKER_TYPE = 485;
+
+	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.WSClientSideBroadcastLevel <em>WS Client Side Broadcast Level</em>}' enum.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -26673,7 +26692,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getWSClientSideBroadcastLevel()
 	 * @generated
 	 */
-	int WS_CLIENT_SIDE_BROADCAST_LEVEL = 485;
+	int WS_CLIENT_SIDE_BROADCAST_LEVEL = 486;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.MQTTSubscriptionQOS <em>MQTT Subscription QOS</em>}' enum.
@@ -26683,7 +26702,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getMQTTSubscriptionQOS()
 	 * @generated
 	 */
-	int MQTT_SUBSCRIPTION_QOS = 486;
+	int MQTT_SUBSCRIPTION_QOS = 487;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.FeedType <em>Feed Type</em>}' enum.
@@ -26693,7 +26712,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getFeedType()
 	 * @generated
 	 */
-	int FEED_TYPE = 487;
+	int FEED_TYPE = 488;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.EnableDisableState <em>Enable Disable State</em>}' enum.
@@ -26703,7 +26722,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getEnableDisableState()
 	 * @generated
 	 */
-	int ENABLE_DISABLE_STATE = 488;
+	int ENABLE_DISABLE_STATE = 489;
 
 	/**
 	 * The meta object id for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.APIVersionType <em>API Version Type</em>}' enum.
@@ -26713,7 +26732,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getAPIVersionType()
 	 * @generated
 	 */
-	int API_VERSION_TYPE = 489;
+	int API_VERSION_TYPE = 490;
 
 	/**
 	 * The meta object id for the '<em>Map</em>' data type.
@@ -26723,7 +26742,7 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getMap()
 	 * @generated
 	 */
-	int MAP = 490;
+	int MAP = 491;
 
 
 	/**
@@ -36661,6 +36680,17 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	EAttribute getInboundEndpoint_TransportJMSDurableSubscriberName();
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSBrokerType <em>Transport JMS Broker Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Transport JMS Broker Type</em>'.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSBrokerType()
+	 * @see #getInboundEndpoint()
+	 * @generated
+	 */
+	EAttribute getInboundEndpoint_TransportJMSBrokerType();
+
+	/**
 	 * Returns the meta object for the attribute '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportMQTTConnectionFactory <em>Transport MQTT Connection Factory</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -44623,6 +44653,16 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 	EEnum getJMSCacheLevel();
 
 	/**
+	 * Returns the meta object for enum '{@link org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType <em>JMS Broker Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for enum '<em>JMS Broker Type</em>'.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType
+	 * @generated
+	 */
+	EEnum getJMSBrokerType();
+
+	/**
 	 * Returns the meta object for enum '{@link org.wso2.developerstudio.eclipse.gmf.esb.WSClientSideBroadcastLevel <em>WS Client Side Broadcast Level</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -52468,6 +52508,14 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 		EAttribute INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME = eINSTANCE.getInboundEndpoint_TransportJMSDurableSubscriberName();
 
 		/**
+		 * The meta object literal for the '<em><b>Transport JMS Broker Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE = eINSTANCE.getInboundEndpoint_TransportJMSBrokerType();
+
+		/**
 		 * The meta object literal for the '<em><b>Transport MQTT Connection Factory</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -59042,6 +59090,16 @@ int FILTER_MEDIATOR_FEATURE_COUNT = MEDIATOR_FEATURE_COUNT + 9;
 		 * @generated
 		 */
 		EEnum JMS_CACHE_LEVEL = eINSTANCE.getJMSCacheLevel();
+
+		/**
+		 * The meta object literal for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType <em>JMS Broker Type</em>}' enum.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType
+		 * @see org.wso2.developerstudio.eclipse.gmf.esb.impl.EsbPackageImpl#getJMSBrokerType()
+		 * @generated
+		 */
+		EEnum JMS_BROKER_TYPE = eINSTANCE.getJMSBrokerType();
 
 		/**
 		 * The meta object literal for the '{@link org.wso2.developerstudio.eclipse.gmf.esb.WSClientSideBroadcastLevel <em>WS Client Side Broadcast Level</em>}' enum.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/InboundEndpoint.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/InboundEndpoint.java
@@ -100,6 +100,7 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSReplyDestination <em>Transport JMS Reply Destination</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSPubSubNoLocal <em>Transport JMS Pub Sub No Local</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSDurableSubscriberName <em>Transport JMS Durable Subscriber Name</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSBrokerType <em>Transport JMS Broker Type</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportMQTTConnectionFactory <em>Transport MQTT Connection Factory</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportMQTTServerHostName <em>Transport MQTT Server Host Name</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportMQTTServerPort <em>Transport MQTT Server Port</em>}</li>
@@ -4743,6 +4744,7 @@ public interface InboundEndpoint extends EsbElement {
 
 	/**
 	 * Returns the value of the '<em><b>Transport JMS Connection Factory Type</b></em>' attribute.
+	 * The default value is <code>"queue"</code>.
 	 * The literals are from the enumeration {@link org.wso2.developerstudio.eclipse.gmf.esb.JMSConnectionFactoryType}.
 	 * <!-- begin-user-doc -->
 	 * <p>
@@ -4754,7 +4756,7 @@ public interface InboundEndpoint extends EsbElement {
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSConnectionFactoryType
 	 * @see #setTransportJMSConnectionFactoryType(JMSConnectionFactoryType)
 	 * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getInboundEndpoint_TransportJMSConnectionFactoryType()
-	 * @model
+	 * @model default="queue"
 	 * @generated
 	 */
 	JMSConnectionFactoryType getTransportJMSConnectionFactoryType();
@@ -5393,6 +5395,36 @@ public interface InboundEndpoint extends EsbElement {
 	 * @generated
 	 */
 	void setTransportJMSDurableSubscriberName(String value);
+
+	/**
+	 * Returns the value of the '<em><b>Transport JMS Broker Type</b></em>' attribute.
+	 * The default value is <code>"OTHER"</code>.
+	 * The literals are from the enumeration {@link org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Transport JMS Broker Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Transport JMS Broker Type</em>' attribute.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType
+	 * @see #setTransportJMSBrokerType(JMSBrokerType)
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getInboundEndpoint_TransportJMSBrokerType()
+	 * @model default="OTHER"
+	 * @generated
+	 */
+	JMSBrokerType getTransportJMSBrokerType();
+
+	/**
+	 * Sets the value of the '{@link org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpoint#getTransportJMSBrokerType <em>Transport JMS Broker Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Transport JMS Broker Type</em>' attribute.
+	 * @see org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType
+	 * @see #getTransportJMSBrokerType()
+	 * @generated
+	 */
+	void setTransportJMSBrokerType(JMSBrokerType value);
 
 	/**
 	 * Returns the value of the '<em><b>Transport MQTT Connection Factory</b></em>' attribute.

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/JMSBrokerType.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/JMSBrokerType.java
@@ -1,0 +1,254 @@
+/**
+ * Copyright 2009-2012 WSO2, Inc. (http://wso2.com)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.developerstudio.eclipse.gmf.esb;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>JMS Broker Type</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * @see org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage#getJMSBrokerType()
+ * @model
+ * @generated
+ */
+public enum JMSBrokerType implements Enumerator {
+	/**
+	 * The '<em><b>WSO2 BROKER PROFILE</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #WSO2_BROKER_PROFILE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	WSO2_BROKER_PROFILE(0, "WSO2_BROKER_PROFILE", "WSO2_BROKER_PROFILE"),
+
+	/**
+	 * The '<em><b>Active MQ</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #ACTIVE_MQ_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	ACTIVE_MQ(1, "ActiveMQ", "ActiveMQ"),
+
+	/**
+	 * The '<em><b>OTHER</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #OTHER_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	OTHER(2, "OTHER", "OTHER");
+
+	/**
+	 * The '<em><b>WSO2 BROKER PROFILE</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>WSO2 BROKER PROFILE</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #WSO2_BROKER_PROFILE
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int WSO2_BROKER_PROFILE_VALUE = 0;
+
+	/**
+	 * The '<em><b>Active MQ</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>Active MQ</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #ACTIVE_MQ
+	 * @model name="ActiveMQ"
+	 * @generated
+	 * @ordered
+	 */
+	public static final int ACTIVE_MQ_VALUE = 1;
+
+	/**
+	 * The '<em><b>OTHER</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of '<em><b>OTHER</b></em>' literal object isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @see #OTHER
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int OTHER_VALUE = 2;
+
+	/**
+	 * An array of all the '<em><b>JMS Broker Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final JMSBrokerType[] VALUES_ARRAY =
+		new JMSBrokerType[] {
+			WSO2_BROKER_PROFILE,
+			ACTIVE_MQ,
+			OTHER,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>JMS Broker Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<JMSBrokerType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>JMS Broker Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static JMSBrokerType get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			JMSBrokerType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>JMS Broker Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static JMSBrokerType getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			JMSBrokerType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>JMS Broker Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static JMSBrokerType get(int value) {
+		switch (value) {
+			case WSO2_BROKER_PROFILE_VALUE: return WSO2_BROKER_PROFILE;
+			case ACTIVE_MQ_VALUE: return ACTIVE_MQ;
+			case OTHER_VALUE: return OTHER;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private JMSBrokerType(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //JMSBrokerType

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbFactoryImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbFactoryImpl.java
@@ -673,6 +673,8 @@ public class EsbFactoryImpl extends EFactoryImpl implements EsbFactory {
 				return createJMSSessionAcknowledgementFromString(eDataType, initialValue);
 			case EsbPackage.JMS_CACHE_LEVEL:
 				return createJMSCacheLevelFromString(eDataType, initialValue);
+			case EsbPackage.JMS_BROKER_TYPE:
+				return createJMSBrokerTypeFromString(eDataType, initialValue);
 			case EsbPackage.WS_CLIENT_SIDE_BROADCAST_LEVEL:
 				return createWSClientSideBroadcastLevelFromString(eDataType, initialValue);
 			case EsbPackage.MQTT_SUBSCRIPTION_QOS:
@@ -943,6 +945,8 @@ public class EsbFactoryImpl extends EFactoryImpl implements EsbFactory {
 				return convertJMSSessionAcknowledgementToString(eDataType, instanceValue);
 			case EsbPackage.JMS_CACHE_LEVEL:
 				return convertJMSCacheLevelToString(eDataType, instanceValue);
+			case EsbPackage.JMS_BROKER_TYPE:
+				return convertJMSBrokerTypeToString(eDataType, instanceValue);
 			case EsbPackage.WS_CLIENT_SIDE_BROADCAST_LEVEL:
 				return convertWSClientSideBroadcastLevelToString(eDataType, instanceValue);
 			case EsbPackage.MQTT_SUBSCRIPTION_QOS:
@@ -7167,6 +7171,26 @@ public class EsbFactoryImpl extends EFactoryImpl implements EsbFactory {
 	 * @generated
 	 */
 	public String convertJMSCacheLevelToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public JMSBrokerType createJMSBrokerTypeFromString(EDataType eDataType, String initialValue) {
+		JMSBrokerType result = JMSBrokerType.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertJMSBrokerTypeToString(EDataType eDataType, Object instanceValue) {
 		return instanceValue == null ? null : instanceValue.toString();
 	}
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/EsbPackageImpl.java
@@ -268,6 +268,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.IterateMediatorOutputConnector;
 import org.wso2.developerstudio.eclipse.gmf.esb.IterateMediatorTargetOutputConnector;
 import org.wso2.developerstudio.eclipse.gmf.esb.IterateTarget;
 import org.wso2.developerstudio.eclipse.gmf.esb.JDBCConnectionInformationType;
+import org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSCacheLevel;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSConnectionFactoryType;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSSessionAcknowledgement;
@@ -3936,6 +3937,13 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * @generated
 	 */
 	private EEnum jmsCacheLevelEEnum = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EEnum jmsBrokerTypeEEnum = null;
 
 	/**
 	 * <!-- begin-user-doc -->
@@ -10634,15 +10642,6 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * @generated
 	 */
 	public EAttribute getInboundEndpoint_InboundHL7Port() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(90);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_InboundHL7AutoAck() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(91);
 	}
 
@@ -10651,7 +10650,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7MessagePreProcessor() {
+	public EAttribute getInboundEndpoint_InboundHL7AutoAck() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(92);
 	}
 
@@ -10660,7 +10659,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7CharSet() {
+	public EAttribute getInboundEndpoint_InboundHL7MessagePreProcessor() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(93);
 	}
 
@@ -10669,7 +10668,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7TimeOut() {
+	public EAttribute getInboundEndpoint_InboundHL7CharSet() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(94);
 	}
 
@@ -10678,7 +10677,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7ValidateMessage() {
+	public EAttribute getInboundEndpoint_InboundHL7TimeOut() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(95);
 	}
 
@@ -10687,7 +10686,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7BuildInvalidMessages() {
+	public EAttribute getInboundEndpoint_InboundHL7ValidateMessage() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(96);
 	}
 
@@ -10696,7 +10695,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundHL7PassThroughInvalidMessages() {
+	public EAttribute getInboundEndpoint_InboundHL7BuildInvalidMessages() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(97);
 	}
 
@@ -10705,7 +10704,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ZookeeperConnect() {
+	public EAttribute getInboundEndpoint_InboundHL7PassThroughInvalidMessages() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(98);
 	}
 
@@ -10714,7 +10713,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_GroupId() {
+	public EAttribute getInboundEndpoint_ZookeeperConnect() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(99);
 	}
 
@@ -10723,97 +10722,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ConsumerType() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(101);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TopicsOrTopicFilter() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(102);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TopicsName() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(103);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TopicFilterFrom() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(104);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TopicFilterName() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(105);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_SimpleConsumerTopic() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(106);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_SimpleConsumerBrokers() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(107);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_SimpleConsumerPort() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(108);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_SimpleConsumerPartition() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(109);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_SimpleConsumerMaxMessagesToRead() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(110);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_ContentType() {
+	public EAttribute getInboundEndpoint_GroupId() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(100);
 	}
 
@@ -10822,7 +10731,88 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ThreadCount() {
+	public EAttribute getInboundEndpoint_ConsumerType() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(102);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TopicsOrTopicFilter() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(103);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TopicsName() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(104);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TopicFilterFrom() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(105);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TopicFilterName() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(106);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_SimpleConsumerTopic() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(107);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_SimpleConsumerBrokers() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(108);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_SimpleConsumerPort() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(109);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_SimpleConsumerPartition() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(110);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_SimpleConsumerMaxMessagesToRead() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(111);
 	}
 
@@ -10831,7 +10821,16 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ConsumerId() {
+	public EAttribute getInboundEndpoint_ContentType() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(101);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_ThreadCount() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(112);
 	}
 
@@ -10840,7 +10839,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_SocketTimeoutMs() {
+	public EAttribute getInboundEndpoint_ConsumerId() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(113);
 	}
 
@@ -10849,7 +10848,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_SocketReceiveBufferBytes() {
+	public EAttribute getInboundEndpoint_SocketTimeoutMs() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(114);
 	}
 
@@ -10858,7 +10857,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_FetchMessageMaxBytes() {
+	public EAttribute getInboundEndpoint_SocketReceiveBufferBytes() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(115);
 	}
 
@@ -10867,7 +10866,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_NumConsumerFetches() {
+	public EAttribute getInboundEndpoint_FetchMessageMaxBytes() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(116);
 	}
 
@@ -10876,7 +10875,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_AutoCommitEnable() {
+	public EAttribute getInboundEndpoint_NumConsumerFetches() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(117);
 	}
 
@@ -10885,79 +10884,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ZookeeperSessionTimeoutMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(130);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_ZookeeperConnectionTimeoutMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(131);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_ZookeeperSyncTimeMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(132);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_OffsetsStorage() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(133);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_OffsetsChannelBackoffMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(134);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_OffsetsChannelSocketTimeoutMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(135);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_OffsetsCommitMaxRetries() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(136);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_DualCommitEnabled() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(137);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_AutoCommitIntervalMs() {
+	public EAttribute getInboundEndpoint_AutoCommitEnable() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(118);
 	}
 
@@ -10966,8 +10893,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_QueuedMaxMessageChunks() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(119);
+	public EAttribute getInboundEndpoint_ZookeeperSessionTimeoutMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(131);
 	}
 
 	/**
@@ -10975,8 +10902,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_RebalanceMaxRetries() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(120);
+	public EAttribute getInboundEndpoint_ZookeeperConnectionTimeoutMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(132);
 	}
 
 	/**
@@ -10984,8 +10911,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_FetchMinBytes() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(121);
+	public EAttribute getInboundEndpoint_ZookeeperSyncTimeMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(133);
 	}
 
 	/**
@@ -10993,8 +10920,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_FetchWaitMaxMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(122);
+	public EAttribute getInboundEndpoint_OffsetsStorage() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(134);
 	}
 
 	/**
@@ -11002,8 +10929,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_RebalanceBackoffMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(123);
+	public EAttribute getInboundEndpoint_OffsetsChannelBackoffMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(135);
 	}
 
 	/**
@@ -11011,8 +10938,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_RefreshLeaderBackoffMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(124);
+	public EAttribute getInboundEndpoint_OffsetsChannelSocketTimeoutMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(136);
 	}
 
 	/**
@@ -11020,8 +10947,8 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_AutoOffsetReset() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(125);
+	public EAttribute getInboundEndpoint_OffsetsCommitMaxRetries() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(137);
 	}
 
 	/**
@@ -11029,43 +10956,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_ConsumerTimeoutMs() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(126);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_ExcludeInternalTopics() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(127);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_PartitionAssignmentStrategy() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(128);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_ClientId() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(129);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_InboundCxfRmHost() {
+	public EAttribute getInboundEndpoint_DualCommitEnabled() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(138);
 	}
 
@@ -11074,7 +10965,115 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundCxfRmPort() {
+	public EAttribute getInboundEndpoint_AutoCommitIntervalMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(119);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_QueuedMaxMessageChunks() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(120);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_RebalanceMaxRetries() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(121);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_FetchMinBytes() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(122);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_FetchWaitMaxMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(123);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_RebalanceBackoffMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(124);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_RefreshLeaderBackoffMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(125);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_AutoOffsetReset() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(126);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_ConsumerTimeoutMs() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(127);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_ExcludeInternalTopics() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(128);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_PartitionAssignmentStrategy() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(129);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_ClientId() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(130);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_InboundCxfRmHost() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(139);
 	}
 
@@ -11083,7 +11082,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_InboundCxfRmConfigFile() {
+	public EAttribute getInboundEndpoint_InboundCxfRmPort() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(140);
 	}
 
@@ -11092,7 +11091,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_EnableSSL() {
+	public EAttribute getInboundEndpoint_InboundCxfRmConfigFile() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(141);
 	}
 
@@ -11101,8 +11100,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getInboundEndpoint_EnableSSL() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(142);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EReference getInboundEndpoint_ServiceParameters() {
-		return (EReference)inboundEndpointEClass.getEStructuralFeatures().get(142);
+		return (EReference)inboundEndpointEClass.getEStructuralFeatures().get(143);
 	}
 
 	/**
@@ -11111,15 +11119,6 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * @generated
 	 */
 	public EAttribute getInboundEndpoint_Suspend() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(143);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionFactory() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(144);
 	}
 
@@ -11128,7 +11127,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerHostName() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionFactory() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(145);
 	}
 
@@ -11137,7 +11136,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerPort() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerHostName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(146);
 	}
 
@@ -11146,7 +11145,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerUserName() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerPort() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(147);
 	}
 
@@ -11155,7 +11154,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerPassword() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerUserName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(148);
 	}
 
@@ -11164,7 +11163,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueName() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerPassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(149);
 	}
 
@@ -11173,7 +11172,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeName() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(150);
 	}
 
@@ -11182,7 +11181,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueDurable() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(151);
 	}
 
@@ -11191,7 +11190,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueExclusive() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueDurable() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(152);
 	}
 
@@ -11200,7 +11199,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueAutoDelete() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueExclusive() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(153);
 	}
 
@@ -11209,7 +11208,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueAutoAck() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueAutoDelete() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(154);
 	}
 
@@ -11218,7 +11217,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueRoutingKey() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueAutoAck() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(155);
 	}
 
@@ -11227,7 +11226,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqQueueDeliveryMode() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueRoutingKey() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(156);
 	}
 
@@ -11236,7 +11235,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeType() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqQueueDeliveryMode() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(157);
 	}
 
@@ -11245,7 +11244,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeDurable() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(158);
 	}
 
@@ -11254,7 +11253,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeAutoDelete() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeDurable() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(159);
 	}
 
@@ -11263,7 +11262,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerVirtualHost() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqExchangeAutoDelete() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(160);
 	}
 
@@ -11272,7 +11271,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqFactoryHeartbeat() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerVirtualHost() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(161);
 	}
 
@@ -11281,7 +11280,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslEnabled() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqFactoryHeartbeat() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(162);
 	}
 
@@ -11290,7 +11289,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystoreLocation() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslEnabled() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(163);
 	}
 
@@ -11299,7 +11298,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystoreType() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystoreLocation() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(164);
 	}
 
@@ -11308,7 +11307,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystorePassword() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystoreType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(165);
 	}
 
@@ -11317,7 +11316,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststoreLocation() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslKeystorePassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(166);
 	}
 
@@ -11326,7 +11325,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststoreType() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststoreLocation() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(167);
 	}
 
@@ -11335,7 +11334,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststorePassword() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststoreType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(168);
 	}
 
@@ -11344,7 +11343,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslVersion() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslTruststorePassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(169);
 	}
 
@@ -11353,7 +11352,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqMessageContentType() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionSslVersion() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(170);
 	}
 
@@ -11362,7 +11361,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionRetryCount() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqMessageContentType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(171);
 	}
 
@@ -11371,7 +11370,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionRetryInterval() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionRetryCount() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(172);
 	}
 
@@ -11380,7 +11379,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqServerRetryInterval() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConnectionRetryInterval() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(173);
 	}
 
@@ -11389,8 +11388,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getInboundEndpoint_TransportRabbitMqServerRetryInterval() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(174);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EReference getInboundEndpoint_TransportRabbitMqConsumerQosKey() {
-		return (EReference)inboundEndpointEClass.getEStructuralFeatures().get(174);
+		return (EReference)inboundEndpointEClass.getEStructuralFeatures().get(175);
 	}
 
 	/**
@@ -11399,15 +11407,6 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * @generated
 	 */
 	public EAttribute getInboundEndpoint_WsInboundPort() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(175);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_WsClientSideBroadcastLevel() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(176);
 	}
 
@@ -11416,7 +11415,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsOutflowDispatchSequence() {
+	public EAttribute getInboundEndpoint_WsClientSideBroadcastLevel() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(177);
 	}
 
@@ -11425,7 +11424,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsOutflowDispatchFaultSequence() {
+	public EAttribute getInboundEndpoint_WsOutflowDispatchSequence() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(178);
 	}
 
@@ -11434,7 +11433,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsBossThreadPoolSize() {
+	public EAttribute getInboundEndpoint_WsOutflowDispatchFaultSequence() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(179);
 	}
 
@@ -11443,7 +11442,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsWorkerThreadPoolSize() {
+	public EAttribute getInboundEndpoint_WsBossThreadPoolSize() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(180);
 	}
 
@@ -11452,7 +11451,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsSubprotocolHandlerClass() {
+	public EAttribute getInboundEndpoint_WsWorkerThreadPoolSize() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(181);
 	}
 
@@ -11461,7 +11460,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsPipelineHandlerClass() {
+	public EAttribute getInboundEndpoint_WsSubprotocolHandlerClass() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(182);
 	}
 
@@ -11470,7 +11469,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportFeedURL() {
+	public EAttribute getInboundEndpoint_WsPipelineHandlerClass() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(183);
 	}
 
@@ -11479,7 +11478,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportFeedType() {
+	public EAttribute getInboundEndpoint_TransportFeedURL() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(184);
 	}
 
@@ -11488,7 +11487,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TraceEnabled() {
+	public EAttribute getInboundEndpoint_TransportFeedType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(185);
 	}
 
@@ -11497,7 +11496,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_StatisticsEnabled() {
+	public EAttribute getInboundEndpoint_TraceEnabled() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(186);
 	}
 
@@ -11506,7 +11505,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportJMSRetriesBeforeSuspension() {
+	public EAttribute getInboundEndpoint_StatisticsEnabled() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(187);
 	}
 
@@ -11515,7 +11514,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportJMSResetConnectionOnPollingSuspension() {
+	public EAttribute getInboundEndpoint_TransportJMSRetriesBeforeSuspension() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(188);
 	}
 
@@ -11524,7 +11523,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportJMSPollingSuspensionPeriod() {
+	public EAttribute getInboundEndpoint_TransportJMSResetConnectionOnPollingSuspension() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(189);
 	}
 
@@ -11533,8 +11532,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslKeystoreLocation() {
+	public EAttribute getInboundEndpoint_TransportJMSPollingSuspensionPeriod() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(190);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TransportMQTTSslKeystoreLocation() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(191);
 	}
 	
 	/**
@@ -11543,15 +11551,6 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * @generated
 	 */
 	public EAttribute getInboundEndpoint_TransportMQTTSslKeystoreType() {
-		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(191);
-	}
-
-	/**
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslKeystorePassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(192);
 	}
 
@@ -11560,7 +11559,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslTruststoreLocation() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslKeystorePassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(193);
 	}
 
@@ -11569,7 +11568,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslTruststoreType() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslTruststoreLocation() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(194);
 	}
 
@@ -11578,7 +11577,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslTruststorePassword() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslTruststoreType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(195);
 	}
 
@@ -11587,7 +11586,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslVersion() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslTruststorePassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(196);
 	}
 
@@ -11596,7 +11595,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslKeyStoreFile() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslVersion() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(197);
 	}
 
@@ -11605,7 +11604,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslKeyStorePass() {
+	public EAttribute getInboundEndpoint_WssSslKeyStoreFile() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(198);
 	}
 
@@ -11614,7 +11613,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslTrustStoreFile() {
+	public EAttribute getInboundEndpoint_WssSslKeyStorePass() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(199);
 	}
 
@@ -11623,7 +11622,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslTrustStorePass() {
+	public EAttribute getInboundEndpoint_WssSslTrustStoreFile() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(200);
 	}
 
@@ -11632,7 +11631,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslCertPass() {
+	public EAttribute getInboundEndpoint_WssSslTrustStorePass() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(201);
 	}
 
@@ -11641,7 +11640,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsDefaultContentType() {
+	public EAttribute getInboundEndpoint_WssSslCertPass() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(202);
 	}
 
@@ -11650,7 +11649,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsShutdownStatusCode() {
+	public EAttribute getInboundEndpoint_WsDefaultContentType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(203);
 	}
 
@@ -11659,7 +11658,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsShutdownStatusMessage() {
+	public EAttribute getInboundEndpoint_WsShutdownStatusCode() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(204);
 	}
 
@@ -11668,7 +11667,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WsUsePortOffset() {
+	public EAttribute getInboundEndpoint_WsShutdownStatusMessage() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(205);
 	}
 
@@ -11677,7 +11676,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslProtocols() {
+	public EAttribute getInboundEndpoint_WsUsePortOffset() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(206);
 	}
 
@@ -11686,7 +11685,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_WssSslCipherSuites() {
+	public EAttribute getInboundEndpoint_WssSslProtocols() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(207);
 	}
 
@@ -11695,7 +11694,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConsumerQos() {
+	public EAttribute getInboundEndpoint_WssSslCipherSuites() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(208);
 	}
 
@@ -11704,8 +11703,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportRabbitMqConsumerQosType() {
+	public EAttribute getInboundEndpoint_TransportRabbitMqConsumerQos() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(209);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_TransportRabbitMqConsumerQosType() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(210);
 	}
 
 	/**
@@ -12334,7 +12342,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTConnectionFactory() {
+	public EAttribute getInboundEndpoint_TransportJMSBrokerType() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(73);
 	}
 
@@ -12343,7 +12351,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTServerHostName() {
+	public EAttribute getInboundEndpoint_TransportMQTTConnectionFactory() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(74);
 	}
 
@@ -12352,7 +12360,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTServerPort() {
+	public EAttribute getInboundEndpoint_TransportMQTTServerHostName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(75);
 	}
 
@@ -12361,7 +12369,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTTopicName() {
+	public EAttribute getInboundEndpoint_TransportMQTTServerPort() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(76);
 	}
 
@@ -12370,7 +12378,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionQOS() {
+	public EAttribute getInboundEndpoint_TransportMQTTTopicName() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(77);
 	}
 
@@ -12379,7 +12387,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSessionClean() {
+	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionQOS() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(78);
 	}
 
@@ -12388,7 +12396,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSslEnable() {
+	public EAttribute getInboundEndpoint_TransportMQTTSessionClean() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(79);
 	}
 
@@ -12397,7 +12405,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTTemporaryStoreDirectory() {
+	public EAttribute getInboundEndpoint_TransportMQTTSslEnable() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(80);
 	}
 
@@ -12406,7 +12414,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionUsername() {
+	public EAttribute getInboundEndpoint_TransportMQTTTemporaryStoreDirectory() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(81);
 	}
 
@@ -12415,7 +12423,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionPassword() {
+	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionUsername() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(82);
 	}
 
@@ -12424,7 +12432,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_TransportMQTTClientId() {
+	public EAttribute getInboundEndpoint_TransportMQTTSubscriptionPassword() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(83);
 	}
 
@@ -12433,7 +12441,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_Truststore() {
+	public EAttribute getInboundEndpoint_TransportMQTTClientId() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(84);
 	}
 
@@ -12442,7 +12450,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_Keystore() {
+	public EAttribute getInboundEndpoint_Truststore() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(85);
 	}
 
@@ -12451,7 +12459,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_SslVerifyClient() {
+	public EAttribute getInboundEndpoint_Keystore() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(86);
 	}
 
@@ -12460,7 +12468,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_SslProtocol() {
+	public EAttribute getInboundEndpoint_SslVerifyClient() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(87);
 	}
 
@@ -12469,7 +12477,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_HttpsProtocols() {
+	public EAttribute getInboundEndpoint_SslProtocol() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(88);
 	}
 
@@ -12478,8 +12486,17 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getInboundEndpoint_CertificateRevocationVerifier() {
+	public EAttribute getInboundEndpoint_HttpsProtocols() {
 		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(89);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getInboundEndpoint_CertificateRevocationVerifier() {
+		return (EAttribute)inboundEndpointEClass.getEStructuralFeatures().get(90);
 	}
 
 	/**
@@ -19084,6 +19101,15 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EEnum getJMSBrokerType() {
+		return jmsBrokerTypeEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EEnum getWSClientSideBroadcastLevel() {
 		return wsClientSideBroadcastLevelEEnum;
 	}
@@ -20910,6 +20936,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_REPLY_DESTINATION);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_PUB_SUB_NO_LOCAL);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME);
+		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME);
 		createEAttribute(inboundEndpointEClass, INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_PORT);
@@ -21196,6 +21223,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		jmsConnectionFactoryTypeEEnum = createEEnum(JMS_CONNECTION_FACTORY_TYPE);
 		jmsSessionAcknowledgementEEnum = createEEnum(JMS_SESSION_ACKNOWLEDGEMENT);
 		jmsCacheLevelEEnum = createEEnum(JMS_CACHE_LEVEL);
+		jmsBrokerTypeEEnum = createEEnum(JMS_BROKER_TYPE);
 		wsClientSideBroadcastLevelEEnum = createEEnum(WS_CLIENT_SIDE_BROADCAST_LEVEL);
 		mqttSubscriptionQOSEEnum = createEEnum(MQTT_SUBSCRIPTION_QOS);
 		feedTypeEEnum = createEEnum(FEED_TYPE);
@@ -23316,7 +23344,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		initEAttribute(getInboundEndpoint_JavaNamingFactoryInitial(), ecorePackage.getEString(), "javaNamingFactoryInitial", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_JavaNamingProviderUrl(), ecorePackage.getEString(), "javaNamingProviderUrl", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSConnectionFactoryJNDIName(), ecorePackage.getEString(), "transportJMSConnectionFactoryJNDIName", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
-		initEAttribute(getInboundEndpoint_TransportJMSConnectionFactoryType(), this.getJMSConnectionFactoryType(), "transportJMSConnectionFactoryType", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getInboundEndpoint_TransportJMSConnectionFactoryType(), this.getJMSConnectionFactoryType(), "transportJMSConnectionFactoryType", "queue", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSConcurrentConsumers(), ecorePackage.getEString(), "transportJMSConcurrentConsumers", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSDestination(), ecorePackage.getEString(), "transportJMSDestination", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSSessionTransacted(), ecorePackage.getEBoolean(), "transportJMSSessionTransacted", "false", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -23340,6 +23368,7 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		initEAttribute(getInboundEndpoint_TransportJMSReplyDestination(), ecorePackage.getEString(), "transportJMSReplyDestination", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSPubSubNoLocal(), ecorePackage.getEString(), "transportJMSPubSubNoLocal", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportJMSDurableSubscriberName(), ecorePackage.getEString(), "transportJMSDurableSubscriberName", null, 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getInboundEndpoint_TransportJMSBrokerType(), this.getJMSBrokerType(), "transportJMSBrokerType", "OTHER", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportMQTTConnectionFactory(), ecorePackage.getEString(), "transportMQTTConnectionFactory", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportMQTTServerHostName(), ecorePackage.getEString(), "transportMQTTServerHostName", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getInboundEndpoint_TransportMQTTServerPort(), ecorePackage.getEString(), "transportMQTTServerPort", "", 0, 1, InboundEndpoint.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
@@ -24238,6 +24267,11 @@ public class EsbPackageImpl extends EPackageImpl implements EsbPackage {
 		addEEnumLiteral(jmsCacheLevelEEnum, JMSCacheLevel.THREE);
 		addEEnumLiteral(jmsCacheLevelEEnum, JMSCacheLevel.TWO);
 		addEEnumLiteral(jmsCacheLevelEEnum, JMSCacheLevel.ONE);
+
+		initEEnum(jmsBrokerTypeEEnum, JMSBrokerType.class, "JMSBrokerType");
+		addEEnumLiteral(jmsBrokerTypeEEnum, JMSBrokerType.WSO2_BROKER_PROFILE);
+		addEEnumLiteral(jmsBrokerTypeEEnum, JMSBrokerType.ACTIVE_MQ);
+		addEEnumLiteral(jmsBrokerTypeEEnum, JMSBrokerType.OTHER);
 
 		initEEnum(wsClientSideBroadcastLevelEEnum, WSClientSideBroadcastLevel.class, "WSClientSideBroadcastLevel");
 		addEEnumLiteral(wsClientSideBroadcastLevelEEnum, WSClientSideBroadcastLevel.ZERO);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb/src/org/wso2/developerstudio/eclipse/gmf/esb/impl/InboundEndpointImpl.java
@@ -43,6 +43,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpointParameter;
 import org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpointSequenceInputConnector;
 import org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpointSequenceOutputConnector;
 import org.wso2.developerstudio.eclipse.gmf.esb.InboundEndpointType;
+import org.wso2.developerstudio.eclipse.gmf.esb.JMSBrokerType;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSCacheLevel;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSConnectionFactoryType;
 import org.wso2.developerstudio.eclipse.gmf.esb.JMSSessionAcknowledgement;
@@ -137,6 +138,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.WSClientSideBroadcastLevel;
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJMSReplyDestination <em>Transport JMS Reply Destination</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJMSPubSubNoLocal <em>Transport JMS Pub Sub No Local</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJMSDurableSubscriberName <em>Transport JMS Durable Subscriber Name</em>}</li>
+ *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportJMSBrokerType <em>Transport JMS Broker Type</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportMQTTConnectionFactory <em>Transport MQTT Connection Factory</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportMQTTServerHostName <em>Transport MQTT Server Host Name</em>}</li>
  *   <li>{@link org.wso2.developerstudio.eclipse.gmf.esb.impl.InboundEndpointImpl#getTransportMQTTServerPort <em>Transport MQTT Server Port</em>}</li>
@@ -1238,7 +1240,7 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 	 * @generated
 	 * @ordered
 	 */
-	protected static final JMSConnectionFactoryType TRANSPORT_JMS_CONNECTION_FACTORY_TYPE_EDEFAULT = JMSConnectionFactoryType.TOPIC;
+	protected static final JMSConnectionFactoryType TRANSPORT_JMS_CONNECTION_FACTORY_TYPE_EDEFAULT = JMSConnectionFactoryType.QUEUE;
 
 	/**
 	 * The cached value of the '{@link #getTransportJMSConnectionFactoryType()
@@ -1736,6 +1738,26 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 	 * @ordered
 	 */
 	protected String transportJMSDurableSubscriberName = TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME_EDEFAULT;
+
+	/**
+	 * The default value of the '{@link #getTransportJMSBrokerType() <em>Transport JMS Broker Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJMSBrokerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final JMSBrokerType TRANSPORT_JMS_BROKER_TYPE_EDEFAULT = JMSBrokerType.OTHER;
+
+	/**
+	 * The cached value of the '{@link #getTransportJMSBrokerType() <em>Transport JMS Broker Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getTransportJMSBrokerType()
+	 * @generated
+	 * @ordered
+	 */
+	protected JMSBrokerType transportJMSBrokerType = TRANSPORT_JMS_BROKER_TYPE_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getTransportMQTTConnectionFactory()
@@ -8375,6 +8397,27 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 	}
 
 	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public JMSBrokerType getTransportJMSBrokerType() {
+		return transportJMSBrokerType;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setTransportJMSBrokerType(JMSBrokerType newTransportJMSBrokerType) {
+		JMSBrokerType oldTransportJMSBrokerType = transportJMSBrokerType;
+		transportJMSBrokerType = newTransportJMSBrokerType == null ? TRANSPORT_JMS_BROKER_TYPE_EDEFAULT : newTransportJMSBrokerType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE, oldTransportJMSBrokerType, transportJMSBrokerType));
+	}
+
+	/**
 	 * <!-- begin-user-doc --> <!-- end-user-doc -->
 	 * @generated
 	 */
@@ -8875,6 +8918,8 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 				return getTransportJMSPubSubNoLocal();
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME:
 				return getTransportJMSDurableSubscriberName();
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE:
+				return getTransportJMSBrokerType();
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY:
 				return getTransportMQTTConnectionFactory();
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME:
@@ -9379,6 +9424,9 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 				return;
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME:
 				setTransportJMSDurableSubscriberName((String)newValue);
+				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE:
+				setTransportJMSBrokerType((JMSBrokerType)newValue);
 				return;
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY:
 				setTransportMQTTConnectionFactory((String)newValue);
@@ -10022,6 +10070,9 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME:
 				setTransportJMSDurableSubscriberName(TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME_EDEFAULT);
 				return;
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE:
+				setTransportJMSBrokerType(TRANSPORT_JMS_BROKER_TYPE_EDEFAULT);
+				return;
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY:
 				setTransportMQTTConnectionFactory(TRANSPORT_MQTT_CONNECTION_FACTORY_EDEFAULT);
 				return;
@@ -10590,6 +10641,8 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 				return TRANSPORT_JMS_PUB_SUB_NO_LOCAL_EDEFAULT == null ? transportJMSPubSubNoLocal != null : !TRANSPORT_JMS_PUB_SUB_NO_LOCAL_EDEFAULT.equals(transportJMSPubSubNoLocal);
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME:
 				return TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME_EDEFAULT == null ? transportJMSDurableSubscriberName != null : !TRANSPORT_JMS_DURABLE_SUBSCRIBER_NAME_EDEFAULT.equals(transportJMSDurableSubscriberName);
+			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_JMS_BROKER_TYPE:
+				return transportJMSBrokerType != TRANSPORT_JMS_BROKER_TYPE_EDEFAULT;
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_CONNECTION_FACTORY:
 				return TRANSPORT_MQTT_CONNECTION_FACTORY_EDEFAULT == null ? transportMQTTConnectionFactory != null : !TRANSPORT_MQTT_CONNECTION_FACTORY_EDEFAULT.equals(transportMQTTConnectionFactory);
 			case EsbPackage.INBOUND_ENDPOINT__TRANSPORT_MQTT_SERVER_HOST_NAME:
@@ -11013,6 +11066,8 @@ public class InboundEndpointImpl extends EsbElementImpl implements InboundEndpoi
 		result.append(transportJMSPubSubNoLocal);
 		result.append(", transportJMSDurableSubscriberName: ");
 		result.append(transportJMSDurableSubscriberName);
+		result.append(", transportJMSBrokerType: ");
+		result.append(transportJMSBrokerType);
 		result.append(", transportMQTTConnectionFactory: ");
 		result.append(transportMQTTConnectionFactory);
 		result.append(", transportMQTTServerHostName: ");


### PR DESCRIPTION
## Purpose
> Added a new property to select the broker type for JMS Inbound Endpoint. The broker type will set the default values for related properties according to the selected broker type.

## Related issue
wso2/product-ei#2228
