### PR TITLE
Fix var match

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
@@ -76,8 +76,6 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 		SchemaDataType outputDataType = null;
 		for (int variableIndex = 0; variableIndex < numOfOutputVariables; variableIndex++) {
 			outputDataType = outputVariables.get(variableIndex).getSchemaVariableType();
-			/*outputDataType = SchemaDataType.valueOf(outputVariables.get(variableIndex).getId()
-					.split("schemaDataType: ")[1].split(",")[0]) ;*/
 		}
 		return outputDataType;
 	}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
@@ -69,5 +69,17 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 		}
 		return operationBuilder.toString();
 	}
+	
+	protected SchemaDataType getOutputVariableType(List<DMVariable> outputVariables)
+			throws DataMapperException {
+		int numOfOutputVariables = outputVariables.size();
+		SchemaDataType outputDataType = null;
+		for (int variableIndex = 0; variableIndex < numOfOutputVariables; variableIndex++) {
+			outputDataType = outputVariables.get(variableIndex).getSchemaVariableType();
+			/*outputDataType = SchemaDataType.valueOf(outputVariables.get(variableIndex).getId()
+					.split("schemaDataType: ")[1].split(",")[0]) ;*/
+		}
+		return outputDataType;
+	}
 
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -19,16 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
-import org.apache.commons.logging.Log;
 import org.wso2.developerstudio.datamapper.SchemaDataType;
-import org.wso2.developerstudio.datamapper.diagram.custom.generator.ForLoopBean;
 import org.wso2.developerstudio.datamapper.diagram.Activator;
+import org.wso2.developerstudio.datamapper.diagram.custom.generator.ForLoopBean;
 import org.wso2.developerstudio.datamapper.diagram.custom.exception.DataMapperException;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.DifferentLevelArrayMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.SameLevelRecordMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMOperation;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariable;
-import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariableType;
 import org.wso2.developerstudio.datamapper.diagram.custom.util.ScriptGenerationUtil;
 import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
 import org.wso2.developerstudio.eclipse.logging.core.Logger;
@@ -96,7 +94,7 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 			return typeConvertedPrettyVariable;
 		} catch (DataMapperException e) {
-			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found.");
+			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found. " + e);
 		}
 	}
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -58,9 +58,6 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
-				/*operationBuilder.append(
-						ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
-								parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ";");*/
 				operationBuilder.append(this.appendTypeCorrectedInputVariable(operationBuilder, inputVariables, variableTypeMap, parentForLoopBeanStack,
 						forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop, outputDataType) + ";");
 			} else {
@@ -79,8 +76,6 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 		try {
 			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
 				parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop);
-			
-			//SchemaDataType inputDataType = ScriptGenerationUtil.getLastVariableTypeInForOperation(inputVariables.get(0), variableTypeMap);
 			SchemaDataType inputDataType = inputVariables.get(0).getSchemaVariableType();
 			String typeConvertedPrettyVariable = "";
 			if(!outputDataType.equals(inputDataType)) {
@@ -100,8 +95,6 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 				typeConvertedPrettyVariable = prettyVariable;
 			}
 			return typeConvertedPrettyVariable;
-			/*operationBuilder.append(typeConvertedPrettyVariable);
-			return operationBuilder.toString();*/
 		} catch (DataMapperException e) {
 			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found.");
 		}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -80,7 +80,7 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			String typeConvertedPrettyVariable = "";
 			if(!outputDataType.equals(inputDataType)) {
 				if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
-					typeConvertedPrettyVariable = "Number('" + prettyVariable + "')";
+					typeConvertedPrettyVariable = "Number(" + prettyVariable + ")";
 				} else if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.BOOLEAN.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "(" + prettyVariable + " == 'true')";
 				} else if((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -67,24 +67,27 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 		return operationBuilder.toString();
 	}
 	
-	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
-			Stack<ForLoopBean> parentForLoopBeanStack, List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
+	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables,
+			Map<String, List<SchemaDataType>> variableTypeMap, Stack<ForLoopBean> parentForLoopBeanStack,
+			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
 			Map<String, Integer> outputArrayRootVariableForLoop, SchemaDataType outputDataType) {
-		
+
 		try {
-			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
-				parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
+					variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop,
+					outputArrayRootVariableForLoop);
 			SchemaDataType inputDataType = inputVariables.get(0).getSchemaVariableType();
 			String typeConvertedPrettyVariable = "";
-			if(!outputDataType.equals(inputDataType)) {
-				if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
+			if (!outputDataType.equals(inputDataType)) {
+				if (SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "Number(" + prettyVariable + ")";
-				} else if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.BOOLEAN.equals(outputDataType)) {
+				} else if (SchemaDataType.STRING.equals(inputDataType)
+						&& SchemaDataType.BOOLEAN.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "(" + prettyVariable + " == 'true')";
-				} else if((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))
+				} else if ((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))
 						&& SchemaDataType.STRING.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "(" + prettyVariable + ").toString()";
-				} else{
+				} else {
 					typeConvertedPrettyVariable = prettyVariable;
 					log.warn("Unidentified type conversion was detected from " + outputDataType.toString() + " to "
 							+ inputDataType.toString() + ".");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
@@ -255,6 +255,24 @@ public class ScriptGenerationUtil {
 		}
 		return prettyVariableName;
 	}
+	
+	public static SchemaDataType getLastVariableTypeInForOperation(DMVariable variable, Map<String, List<SchemaDataType>> map)
+			throws DataMapperException {
+		
+		SchemaDataType inputVariableType = null;
+		String variableName = "";
+		
+		if (DMVariableType.INPUT.equals(variable.getType())) {
+			String[] variableNameArray = variable.getName().split("\\.");
+			for (String nextName : variableNameArray) {
+				variableName += nextName;
+				if (map.containsKey(variableName)) {
+					inputVariableType = map.get(variableName).get(VARIABLE_TYPE_INDEX);
+				}
+			}
+		}
+		return inputVariableType;
+	}
 
 	public static ForLoopBean getForLoopFromMappedVariableArrayName(String mappedInputVariableArrayElement,
 			List<ForLoopBean> forLoopBeanList) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
@@ -258,10 +258,8 @@ public class ScriptGenerationUtil {
 	
 	public static SchemaDataType getLastVariableTypeInForOperation(DMVariable variable, Map<String, List<SchemaDataType>> map)
 			throws DataMapperException {
-		
 		SchemaDataType inputVariableType = null;
 		String variableName = "";
-		
 		if (DMVariableType.INPUT.equals(variable.getType())) {
 			String[] variableNameArray = variable.getName().split("\\.");
 			for (String nextName : variableNameArray) {


### PR DESCRIPTION
## Purpose
> Resolves issue 2762

## Goals
> When Data Mapper maps to different data types (for e.g. From Integer to String), it would automatically convert data types.

## Approach
> Nothing specific to be done. When dragged from input to output message schema in Data Mapper, it will correctly map intuitively.

## User stories
> A user drags from data entity A which has type String to data entity B which has type Integer. It will automatically convert the input String value to an Integer inside the Data Mapper.

## Release note
> N/A

## Documentation
> N/A as this is a bug fix which is implicit to be happened when working correctly.

## Training
> N/A as intuition does not need any training.

## Certification
> N/A as intuitive user operation cannot be given as a training or as a certification question.

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Do intuitively mapping the different data types.

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Dev studio
 
## Learning
> N/A