### PR TITLE
Add fix of automatically converting data types in data mapper.

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
@@ -69,5 +69,15 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 		}
 		return operationBuilder.toString();
 	}
+	
+	protected SchemaDataType getOutputVariableType(List<DMVariable> outputVariables)
+			throws DataMapperException {
+		int numOfOutputVariables = outputVariables.size();
+		SchemaDataType outputDataType = null;
+		for (int variableIndex = 0; variableIndex < numOfOutputVariables; variableIndex++) {
+			outputDataType = outputVariables.get(variableIndex).getSchemaVariableType();
+		}
+		return outputDataType;
+	}
 
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
@@ -70,14 +70,9 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 		return operationBuilder.toString();
 	}
 	
-	protected SchemaDataType getOutputVariableType(List<DMVariable> outputVariables)
-			throws DataMapperException {
-		int numOfOutputVariables = outputVariables.size();
-		SchemaDataType outputDataType = null;
-		for (int variableIndex = 0; variableIndex < numOfOutputVariables; variableIndex++) {
-			outputDataType = outputVariables.get(variableIndex).getSchemaVariableType();
-		}
-		return outputDataType;
+	protected SchemaDataType getOutputVariableType(List<DMVariable> outputVariables) throws DataMapperException {
+		DMVariable lastVariable = outputVariables.get(outputVariables.size() - 1);
+		return lastVariable.getSchemaVariableType();
 	}
 
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -19,20 +19,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import org.apache.commons.logging.Log;
 import org.wso2.developerstudio.datamapper.SchemaDataType;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.ForLoopBean;
+import org.wso2.developerstudio.datamapper.diagram.Activator;
 import org.wso2.developerstudio.datamapper.diagram.custom.exception.DataMapperException;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.DifferentLevelArrayMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.SameLevelRecordMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMOperation;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariable;
+import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariableType;
 import org.wso2.developerstudio.datamapper.diagram.custom.util.ScriptGenerationUtil;
+import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
+import org.wso2.developerstudio.eclipse.logging.core.Logger;
 
 /**
  * This class extended from the {@link AbstractDMOperatorTransformer} abstract
  * class and generate script for direct operation
  */
 public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
+	
+	private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
 
 	@Override
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
@@ -42,6 +49,7 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
 				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+		SchemaDataType outputDataType = getOutputVariableType(outputVariables);
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(inputVariables.get(0).getName() + ";");
@@ -50,9 +58,8 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
-				operationBuilder.append(
-						ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
-								parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ";");
+				operationBuilder.append(this.appendTypeCorrectedInputVariable(operationBuilder, inputVariables, variableTypeMap, parentForLoopBeanStack,
+						forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop, outputDataType) + ";");
 			} else {
 				operationBuilder.append("'';");
 			}
@@ -60,5 +67,36 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found : " + generatorClass);
 		}
 		return operationBuilder.toString();
+	}
+	
+	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
+			Stack<ForLoopBean> parentForLoopBeanStack, List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, SchemaDataType outputDataType) {
+		
+		try {
+			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
+				parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+			SchemaDataType inputDataType = inputVariables.get(0).getSchemaVariableType();
+			String typeConvertedPrettyVariable = "";
+			if(!outputDataType.equals(inputDataType)) {
+				if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
+					typeConvertedPrettyVariable = "Number(" + prettyVariable + ")";
+				} else if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.BOOLEAN.equals(outputDataType)) {
+					typeConvertedPrettyVariable = "(" + prettyVariable + " == 'true')";
+				} else if((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))
+						&& SchemaDataType.STRING.equals(outputDataType)) {
+					typeConvertedPrettyVariable = "(" + prettyVariable + ").toString()";
+				} else{
+					typeConvertedPrettyVariable = prettyVariable;
+					log.warn("Unidentified type conversion was detected from " + outputDataType.toString() + " to "
+							+ inputDataType.toString() + ".");
+				}
+			} else {
+				typeConvertedPrettyVariable = prettyVariable;
+			}
+			return typeConvertedPrettyVariable;
+		} catch (DataMapperException e) {
+			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found.");
+		}
 	}
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -19,16 +19,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
-import org.apache.commons.logging.Log;
 import org.wso2.developerstudio.datamapper.SchemaDataType;
-import org.wso2.developerstudio.datamapper.diagram.custom.generator.ForLoopBean;
 import org.wso2.developerstudio.datamapper.diagram.Activator;
+import org.wso2.developerstudio.datamapper.diagram.custom.generator.ForLoopBean;
 import org.wso2.developerstudio.datamapper.diagram.custom.exception.DataMapperException;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.DifferentLevelArrayMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.generator.SameLevelRecordMappingConfigGenerator;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMOperation;
 import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariable;
-import org.wso2.developerstudio.datamapper.diagram.custom.model.DMVariableType;
 import org.wso2.developerstudio.datamapper.diagram.custom.util.ScriptGenerationUtil;
 import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
 import org.wso2.developerstudio.eclipse.logging.core.Logger;
@@ -38,14 +36,15 @@ import org.wso2.developerstudio.eclipse.logging.core.Logger;
  * class and generate script for direct operation
  */
 public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
-	
+
 	private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
 
 	@Override
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
 				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
@@ -58,8 +57,9 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
-				operationBuilder.append(this.appendTypeCorrectedInputVariable(operationBuilder, inputVariables, variableTypeMap, parentForLoopBeanStack,
-						forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop, outputDataType) + ";");
+				operationBuilder.append(this.appendTypeCorrectedInputVariable(operationBuilder, inputVariables,
+						variableTypeMap, parentForLoopBeanStack, forLoopBeanList, outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, outputDataType) + ";");
 			} else {
 				operationBuilder.append("'';");
 			}
@@ -68,25 +68,27 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 		}
 		return operationBuilder.toString();
 	}
-	
-	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
-			Stack<ForLoopBean> parentForLoopBeanStack, List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
+
+	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables,
+			Map<String, List<SchemaDataType>> variableTypeMap, Stack<ForLoopBean> parentForLoopBeanStack,
+			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
 			Map<String, Integer> outputArrayRootVariableForLoop, SchemaDataType outputDataType) {
-		
 		try {
-			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
-				parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
+					variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop,
+					outputArrayRootVariableForLoop);
 			SchemaDataType inputDataType = inputVariables.get(0).getSchemaVariableType();
 			String typeConvertedPrettyVariable = "";
-			if(!outputDataType.equals(inputDataType)) {
-				if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
+			if (!outputDataType.equals(inputDataType)) {
+				if (SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.NUMBER.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "Number(" + prettyVariable + ")";
-				} else if(SchemaDataType.STRING.equals(inputDataType) && SchemaDataType.BOOLEAN.equals(outputDataType)) {
+				} else if (SchemaDataType.STRING.equals(inputDataType)
+						&& SchemaDataType.BOOLEAN.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "(" + prettyVariable + " == 'true')";
-				} else if((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))
+				} else if ((SchemaDataType.NUMBER.equals(inputDataType) || SchemaDataType.BOOLEAN.equals(inputDataType))
 						&& SchemaDataType.STRING.equals(outputDataType)) {
 					typeConvertedPrettyVariable = "(" + prettyVariable + ").toString()";
-				} else{
+				} else {
 					typeConvertedPrettyVariable = prettyVariable;
 					log.warn("Unidentified type conversion was detected from " + outputDataType.toString() + " to "
 							+ inputDataType.toString() + ".");
@@ -96,7 +98,7 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 			return typeConvertedPrettyVariable;
 		} catch (DataMapperException e) {
-			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found.");
+			throw new IllegalArgumentException("Unknown MappingConfigGenerator type found. " + e);
 		}
 	}
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
@@ -255,6 +255,22 @@ public class ScriptGenerationUtil {
 		}
 		return prettyVariableName;
 	}
+	
+	public static SchemaDataType getLastVariableTypeInForOperation(DMVariable variable, Map<String, List<SchemaDataType>> map)
+			throws DataMapperException {
+		SchemaDataType inputVariableType = null;
+		String variableName = "";
+		if (DMVariableType.INPUT.equals(variable.getType())) {
+			String[] variableNameArray = variable.getName().split("\\.");
+			for (String nextName : variableNameArray) {
+				variableName += nextName;
+				if (map.containsKey(variableName)) {
+					inputVariableType = map.get(variableName).get(VARIABLE_TYPE_INDEX);
+				}
+			}
+		}
+		return inputVariableType;
+	}
 
 	public static ForLoopBean getForLoopFromMappedVariableArrayName(String mappedInputVariableArrayElement,
 			List<ForLoopBean> forLoopBeanList) {


### PR DESCRIPTION
## Purpose
> Resolves issue 2762

## Goals
> When Data Mapper maps to different data types (for e.g. From Integer to String), it would automatically convert data types.

## Approach
> Nothing specific to be done. When dragged from input to output message schema in Data Mapper, it will correctly map intuitively.

## User stories
> A user drags from data entity A which has type String to data entity B which has type Integer. It will automatically convert the input String value to an Integer inside the Data Mapper.

## Release note
> N/A

## Documentation
> N/A as this is a bug fix which is implicit to be happened when working correctly.

## Training
> N/A as intuition does not need any training.

## Certification
> N/A as intuitive user operation cannot be given as a training or as a certification question.

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Do intuitively mapping the different data types.

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> Dev studio
 
## Learning
> N/A