### PR TITLE
Move data attribute arrows into the selectable region.

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/DataMapperColorConstants.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/DataMapperColorConstants.java
@@ -25,6 +25,7 @@ public class DataMapperColorConstants {
 	public static final Color outputTitleBarColor = new Color(null, 241, 196, 15);
 	public static final Color titleBarColor = new Color(null, 155, 89, 182);
 	public static final Color highlightNodeColor = new Color(null, 41, 128, 185);
+	public static final Color highlightNodeBackColor = new Color(null, 255, 255, 0);
 	public static final Color borderColor = new Color(null, 71, 68, 68);
 	public static final Color connectorColor = new Color(null, 71, 68, 68);
 	public static final Color color_white = new Color(null, 255, 255, 255);

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/InNodeEditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/InNodeEditPart.java
@@ -18,6 +18,7 @@ package org.wso2.developerstudio.datamapper.diagram.edit.parts;
 
 import java.util.HashMap;
 
+import org.eclipse.draw2d.GridLayout;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.ImageFigure;
 import org.eclipse.draw2d.MouseEvent;
@@ -280,15 +281,19 @@ public class InNodeEditPart extends AbstractInNodeEditPart {
 		 */
 		private void createContents() {
 			int nodeDimension = 10; // width for connection nodes
-
 			ImageFigure mainImg = new ImageFigure(ImageHolder.getInstance().getArrowBlueImage());
 			mainImg.setSize(new Dimension(nodeDimension, nodeDimension));
 			RectangleFigure mainImageRectangle = new RectangleFigure();
 			mainImageRectangle.setOutline(false);
 			mainImageRectangle.setBackgroundColor(new Color(null, 255, 255, 255));
-			mainImageRectangle.setPreferredSize(new Dimension(nodeDimension, nodeDimension));
+			mainImageRectangle.setPreferredSize(new Dimension(nodeDimension*2, nodeDimension));
+			ImageFigure fillImg = new ImageFigure(ImageHolder.getInstance().getArrowBlueImage());
+			fillImg.setSize(new Dimension(nodeDimension, nodeDimension));
+			GridLayout gridLayout = new GridLayout();
+			gridLayout.marginHeight = 0;
+			gridLayout.marginWidth = nodeDimension;
+			mainImageRectangle.setLayoutManager(gridLayout);
 			mainImageRectangle.add(mainImg);
-
 			mainImageRectangle.setFill(false);
 			mainImageRectangle.setOutline(false);
 			this.add(mainImageRectangle);

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/OutNodeEditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/OutNodeEditPart.java
@@ -321,7 +321,7 @@ public class OutNodeEditPart extends AbstractBorderItemEditPart {
 			RectangleFigure mainImageRectangle = new RectangleFigure();
 			mainImageRectangle.setOutline(false);
 			mainImageRectangle.setBackgroundColor(new Color(null, 255, 255, 255));
-			mainImageRectangle.setPreferredSize(new Dimension(nodeDimension, nodeDimension));
+			mainImageRectangle.setPreferredSize(new Dimension(nodeDimension*2, nodeDimension));
 			mainImageRectangle.add(mainImg);
 
 			mainImageRectangle.setFill(false);

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode2EditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode2EditPart.java
@@ -919,7 +919,10 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseEntered(MouseEvent me) {
-					highlightElementOnSelection();
+					String type = getNodeType();
+					if(!type.equals(JSON_SCHEMA_ARRAY) && !type.equals(JSON_SCHEMA_OBJECT)){
+						highlightElementOnSelection();
+					}
 					if (!(getEditDomain().getPaletteViewer().getActiveTool() instanceof PaletteToolEntry)) {
 						getEditDomain().getPaletteViewer()
 								.setActiveTool((ToolEntry) (((PaletteContainer) getEditDomain().getPaletteViewer()
@@ -939,7 +942,6 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseHover(MouseEvent me) {
-					highlightElementOnSelection();
 
 				}
 
@@ -1227,6 +1229,9 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 			newLabel.setForegroundColor(bckGrndColor);
 			rectFigure.remove(childrenList.get(1));
 			rectFigure.add(newLabel);
+			Figure attribFigure = (Figure)((this.getParent().getParent()).getChildren().get(0));
+			attribFigure.setOpaque(true);
+			attribFigure.setBackgroundColor(DataMapperColorConstants.highlightNodeBackColor);
 		}
 
 		public void removeHighlight() {
@@ -1238,6 +1243,9 @@ public class TreeNode2EditPart extends AbstractBorderedShapeEditPart {
 			newLabel.setForegroundColor(bckGrndColor);
 			rectFigure.remove(childrenList.get(1));
 			rectFigure.add(newLabel);
+			Figure attribFigure = (Figure)((this.getParent().getParent()).getChildren().get(0));
+			attribFigure.setOpaque(false);
+			attribFigure.setBackgroundColor(DataMapperColorConstants.inputBoxFillColor);
 		}
 	}
 

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode3EditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNode3EditPart.java
@@ -839,7 +839,6 @@ public class TreeNode3EditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseEntered(MouseEvent me) {
-					highlightElementOnSelection();
 					if (!(getEditDomain().getPaletteViewer().getActiveTool() instanceof PaletteToolEntry)) {
 						getEditDomain().getPaletteViewer()
 								.setActiveTool((ToolEntry) (((PaletteContainer) getEditDomain().getPaletteViewer()
@@ -860,8 +859,6 @@ public class TreeNode3EditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseHover(MouseEvent me) {
-					highlightElementOnSelection();
-
 				}
 
 				@Override

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNodeEditPart.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/edit/parts/TreeNodeEditPart.java
@@ -802,7 +802,6 @@ public class TreeNodeEditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseEntered(MouseEvent me) {
-					highlightElementOnSelection();
 					if (!(getEditDomain().getPaletteViewer().getActiveTool() instanceof PaletteToolEntry)) {
 						getEditDomain().getPaletteViewer()
 								.setActiveTool((ToolEntry) (((PaletteContainer) getEditDomain().getPaletteViewer()
@@ -821,8 +820,6 @@ public class TreeNodeEditPart extends AbstractBorderedShapeEditPart {
 
 				@Override
 				public void mouseHover(MouseEvent me) {
-					highlightElementOnSelection();
-
 				}
 
 				@Override


### PR DESCRIPTION
## Purpose
> Resolves the issues of unclickable arrow parts in Data Mapper and making the items highlighted when mouse pointer is moved over them to identify the items that can be mapped.

## Goals
> Arrow heads are moved into the input and output edit parts and added highlight to whole selected attributes in data mapper.

## Approach
> N/A
## User stories
> When user maps from input to output in Data Mapper they are more intuitive to user to identify the selected items.

## Release note
> N/A

## Documentation
> Not related as they are usability improvements

## Training
> N/A

## Certification
> N/A because they are not to be explicitly said as they follow the existing flow of events to be done.

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Not possible as not supported to dev studio
 - Integration tests
   > Not possible as not supported to dev studio

## Security checks
 - no as not related
 - no as not related
 - Yes

## Samples
> Not required

## Related PRs
> None

## Migrations (if applicable)
> N/A
## Test environment
> All Dev Studio environments are supported
 
## Learning
> Not required as they can be learned intuitively.