### PR TITLE
Remove obsolete fields from RegistryKeyPropertyEditor

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/RegistryKeyPropertyPropertiesEditionPartImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/RegistryKeyPropertyPropertiesEditionPartImpl.java
@@ -93,11 +93,8 @@ public class RegistryKeyPropertyPropertiesEditionPartImpl extends CompositePrope
 	public void createControls(Composite view) { 
 		CompositionSequence registryKeyPropertyStep = new BindingCompositionSequence(propertiesEditionComponent);
 		CompositionStep propertiesStep = registryKeyPropertyStep.addStep(EsbViewsRepository.RegistryKeyProperty.Properties.class);
-		propertiesStep.addStep(EsbViewsRepository.RegistryKeyProperty.Properties.prettyName);
 		propertiesStep.addStep(EsbViewsRepository.RegistryKeyProperty.Properties.keyName);
 		propertiesStep.addStep(EsbViewsRepository.RegistryKeyProperty.Properties.keyValue);
-		propertiesStep.addStep(EsbViewsRepository.RegistryKeyProperty.Properties.filters);
-		
 		
 		composer = new PartComposer(registryKeyPropertyStep) {
 


### PR DESCRIPTION
## Purpose
Removing unnecessary fields (Pretty Name, Filters) from RegistryKeyPropertyEditor.