### PR TITLE
Remove unused jars from compile order

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.cloud/build.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.cloud/build.properties
@@ -28,48 +28,7 @@ src.includes = .classpath,\
                lib/core-3.8.2-v20120916-1200.jar,\
                lib/guava-20.0.jar
 jars.compile.order = .,\
-                     lib/docker-client-8.15.0-shaded.jar,\
-                     lib/slf4j-api-1.7.22.jar,\
-                     lib/commons-compress-1.18.jar,\
-                     lib/activation-1.1.jar,\
-                     lib/bcpkix-jdk15on-1.60.jar,\
-                     lib/commons-io-2.5.jar,\
-                     lib/commons-lang-2.6.jar,\
-                     lib/docker-client-8.14.5.jar,\
-                     lib/google-auth-library-oauth2-http-0.6.0.jar,\
                      lib/guava-20.0.jar,\
                      lib/httpclient-4.5.jar,\
                      lib/httpcore-4.4.5.jar,\
-                     lib/jackson-databind-2.9.6.jar,\
-                     lib/jackson-datatype-guava-2.9.6.jar,\
-                     lib/jackson-jaxrs-json-provider-2.9.6.jar,\
-                     lib/jersey-apache-connector-2.22.2.jar,\
-                     lib/jersey-client-2.22.2.jar,\
-                     lib/jersey-media-json-jackson-2.22.2.jar,\
-                     lib/jnr-unixsocket-0.18.jar,\
-                     lib/javax.ws.rs-api-2.0.1.jar,\
-                     lib/hk2-api-2.4.0-b34.jar,\
-                     lib/jackson-core-2.9.6.jar,\
-                     lib/jackson-annotations-2.9.0.jar,\
-                     lib/jersey-common-2.22.2.jar,\
-                     lib/jersey-guava-2.22.2.jar,\
-                     lib/javax.annotation-api-1.2.jar,\
-                     lib/hk2-utils-2.4.0-b34.jar,\
-                     lib/hk2-locator-2.4.0-b34.jar,\
-                     lib/osgi-resource-locator-1.0.1.jar,\
-                     lib/jackson-jaxrs-base-2.9.6.jar,\
-                     lib/jersey-entity-filtering-2.22.2.jar,\
-                     lib/jffi-1.2.15-native.jar,\
-                     lib/jffi-1.2.15.jar,\
-                     lib/jnr-constants-0.9.8.jar,\
-                     lib/jnr-enxio-0.16.jar,\
-                     lib/jnr-ffi-2.1.4.jar,\
-                     lib/jnr-posix-3.0.35.jar,\
-                     lib/jnr-x86asm-1.0.2.jar,\
-                     lib/asm-5.0.3.jar,\
-                     lib/asm-analysis-5.0.3.jar,\
-                     lib/asm-commons-5.0.3.jar,\
-                     lib/asm-tree-5.0.3.jar,\
-                     lib/asm-util-5.0.3.jar,\
-                     lib/commons-codec-1.9.jar
 


### PR DESCRIPTION
## Purpose
> To remove unused jars from compile order

## Approach
>  Removed unused jars from compiler order in build.properties