### PR TITLE
Fix issue with 'Proxying a SOAP service' template

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/Samples/ProxyingSoapServiceTemplate/ReadMe.html
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/Samples/ProxyingSoapServiceTemplate/ReadMe.html
@@ -58,10 +58,15 @@
                      <li>
                         <h3>Create a request payload file named request.xml with the following content:</h3>
                         <pre><code class="language-xml">
-                                        &lt;echo:echoString xmlns:echo="http://echo.services.core.carbon.wso2.org"&gt;
-                                            &lt;in&gt;Hello&lt;/in&gt;
-                                        &lt;/echo:echoString&gt;
-                                    </code></pre>
+                            &lt;soapenv:Envelope xmlns:soapenv=&quot;http://schemas.xmlsoap.org/soap/envelope/&quot;&gt;
+                                &lt;soapenv:Header/&gt;
+                                &lt;soapenv:Body&gt;
+                                    &lt;echo:echoString xmlns:echo=&quot;http://echo.services.core.carbon.wso2.org&quot;&gt;
+                                        &lt;in&gt;Hello&lt;/in&gt;
+                                    &lt;/echo:echoString&gt;
+                                &lt;/soapenv:Body&gt;
+                            &lt;/soapenv:Envelope&gt;   
+                        </code></pre>
                      </li>
                      <li>
                         <h3>Invoke the service with the following request. Use an HTTP client like cURL.</h3>

--- a/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/Samples/ProxyingSoapServiceTemplate/src/main/synapse-config/endpoints/EchoSoapEP.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/Samples/ProxyingSoapServiceTemplate/src/main/synapse-config/endpoints/EchoSoapEP.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <endpoint name="EchoSoapEP" xmlns="http://ws.apache.org/ns/synapse">
-    <address format="soap11" uri="http://localhost:8280/services/echo"/>
+    <address format="soap11" uri="http://localhost:8290/services/echo"/>
 </endpoint>


### PR DESCRIPTION
## Purpose
> Resolves #3065

## Goals
> Fix inconsistencies in the Template Guide.  

## Approach
> The XML body had to be changed to be wrapped inside a SOAP envelope to comply with SOAP 1.1 and 1.2 standards.

> Port of the sample synapse configuration was changed to 8290, which is the default port of the Micro Integrator