### PR TITLE
Fix Switch case mediator regex spacing and key events

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
@@ -207,6 +207,14 @@ public class SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl extends Co
 				}
 			}
 			
+			@Override
+			public void keyPressed(KeyEvent e) {
+			    if (e.keyCode == SWT.TRAVERSE_RETURN){
+			        if (propertiesEditionComponent != null)
+                        propertiesEditionComponent.firePropertiesChanged(new PropertiesEditionEvent(SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.this, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex, PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
+			    }
+			}
+			
 
 		});
 		EditingUtils.setID(caseRegex, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
@@ -190,32 +190,36 @@ public class SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl extends Co
 		GridData caseRegexData = new GridData(GridData.FILL_HORIZONTAL);
 		caseRegex.setLayoutData(caseRegexData);
 		
-		caseRegex.addKeyListener(new KeyAdapter() {
+        caseRegex.addKeyListener(new KeyAdapter() {
 
-			/**
-			 * {@inheritDoc}
-			 * 
-			 * @see org.eclipse.swt.events.KeyAdapter#keyPressed(org.eclipse.swt.events.KeyEvent)
-			 * 
-			 */
-			@Override
-			@SuppressWarnings("synthetic-access")
-			public void keyReleased(KeyEvent e) {
-				if (!EEFPropertyViewUtil.isReservedKeyCombination(e)) {
-					if (propertiesEditionComponent != null)
-						propertiesEditionComponent.firePropertiesChanged(new PropertiesEditionEvent(SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.this, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex, PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
-				}
-			}
-			
-			@Override
-			public void keyPressed(KeyEvent e) {
-			    if (e.keyCode == SWT.TRAVERSE_RETURN){
-			        if (propertiesEditionComponent != null)
-                        propertiesEditionComponent.firePropertiesChanged(new PropertiesEditionEvent(SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.this, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex, PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
-			    }
-			}
-			
+            /**
+             * {@inheritDoc}
+             * 
+             * @see org.eclipse.swt.events.KeyAdapter#keyPressed(org.eclipse.swt.events.KeyEvent)
+             * 
+             */
+            @Override
+            @SuppressWarnings("synthetic-access")
+            public void keyReleased(KeyEvent e) {
+                if (!EEFPropertyViewUtil.isReservedKeyCombination(e)) {
+                    if (propertiesEditionComponent != null)
+                        propertiesEditionComponent.firePropertiesChanged(new PropertiesEditionEvent(
+                                SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.this,
+                                EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex,
+                                PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
+                }
+            }
 
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.keyCode == SWT.TRAVERSE_RETURN) {
+                    if (propertiesEditionComponent != null)
+                        propertiesEditionComponent.firePropertiesChanged(new PropertiesEditionEvent(
+                                SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.this,
+                                EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex,
+                                PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
+                }
+            }
 		});
 		EditingUtils.setID(caseRegex, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex);
 		EditingUtils.setEEFtype(caseRegex, "eef::Text"); //$NON-NLS-1$

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/impl/SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl.java
@@ -184,12 +184,13 @@ public class SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl extends Co
 	}
 
 	
-	protected Composite createCaseRegexText(Composite parent) {
-		createDescription(parent, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex, EsbMessages.SwitchCaseBranchOutputConnectorPropertiesEditionPart_CaseRegexLabel);
-		caseRegex = SWTUtils.createScrollableText(parent, SWT.BORDER);
-		GridData caseRegexData = new GridData(GridData.FILL_HORIZONTAL);
-		caseRegex.setLayoutData(caseRegexData);
-		
+    protected Composite createCaseRegexText(Composite parent) {
+        createDescription(parent, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex,
+                EsbMessages.SwitchCaseBranchOutputConnectorPropertiesEditionPart_CaseRegexLabel);
+        caseRegex = SWTUtils.createScrollableText(parent, SWT.BORDER);
+        GridData caseRegexData = new GridData(GridData.FILL_HORIZONTAL);
+        caseRegex.setLayoutData(caseRegexData);
+
         caseRegex.addKeyListener(new KeyAdapter() {
 
             /**
@@ -220,15 +221,19 @@ public class SwitchCaseBranchOutputConnectorPropertiesEditionPartImpl extends Co
                                 PropertiesEditionEvent.COMMIT, PropertiesEditionEvent.SET, null, caseRegex.getText()));
                 }
             }
-		});
-		EditingUtils.setID(caseRegex, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex);
-		EditingUtils.setEEFtype(caseRegex, "eef::Text"); //$NON-NLS-1$
-		SWTUtils.createHelpButton(parent, propertiesEditionComponent.getHelpContent(EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex, EsbViewsRepository.SWT_KIND), null); //$NON-NLS-1$
-		// Start of user code for createCaseRegexText
+        });
+        EditingUtils.setID(caseRegex, EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex);
+        EditingUtils.setEEFtype(caseRegex, "eef::Text"); //$NON-NLS-1$
+        SWTUtils.createHelpButton(parent,
+                propertiesEditionComponent.getHelpContent(
+                        EsbViewsRepository.SwitchCaseBranchOutputConnector.Properties.caseRegex,
+                        EsbViewsRepository.SWT_KIND),
+                null); // $NON-NLS-1$
+        // Start of user code for createCaseRegexText
 
-		// End of user code
-		return parent;
-	}
+        // End of user code
+        return parent;
+    }
 
 
 	/**

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/SwitchCaseBranchOutputConnectorItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/SwitchCaseBranchOutputConnectorItemProvider.java
@@ -105,7 +105,7 @@ public class SwitchCaseBranchOutputConnectorItemProvider extends OutputConnector
         String label = ((SwitchCaseBranchOutputConnector)object).getCaseRegex();
         return label == null || label.length() == 0 ?
             getString("_UI_SwitchCaseBranchOutputConnector_type") :
-            getString("_UI_SwitchCaseBranchOutputConnector_type") + " " + label;
+            getString("_UI_SwitchCaseBranchOutputConnector_type") + "\t\t" + label;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Resolves [#3559](https://github.com/wso2/product-ei/issues/3559)

## Goals
> Add tab spacing between Case regex label and regex value
> Persist regex value on enter