### PR TITLE
Add Command mediator key-value details to its property view

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CommandPropertyItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CommandPropertyItemProvider.java
@@ -28,8 +28,10 @@ import org.eclipse.emf.edit.provider.ItemProviderAdapter;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 
 import org.wso2.developerstudio.eclipse.gmf.esb.CommandProperty;
+import org.wso2.developerstudio.eclipse.gmf.esb.CommandPropertyValueType;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbFactory;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
+import org.wso2.developerstudio.eclipse.gmf.esb.presentation.EEFPropertyViewUtil;
 
 /**
  * This is the item provider adapter for a {@link org.wso2.developerstudio.eclipse.gmf.esb.CommandProperty} object.
@@ -251,15 +253,37 @@ public class CommandPropertyItemProvider extends ItemProviderAdapter implements 
      * This returns the label text for the adapted class.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
+     * @generated NOT
      */
 
     @Override
     public String getText(Object object) {
-        String label = ((CommandProperty)object).getPropertyName();
-        return label == null || label.length() == 0 ?
-            getString("_UI_CommandProperty_type") :
-            getString("_UI_CommandProperty_type") + " " + label;
+        String propertyName = ((CommandProperty) object).getPropertyName();
+        String valueType = ((CommandProperty) object).getValueType().toString();
+        String valueLiteral = ((CommandProperty) object).getValueLiteral();
+        String valueContextProperty = ((CommandProperty) object).getValueContextPropertyName().toString();
+
+        if (valueType.equalsIgnoreCase(CommandPropertyValueType.LITERAL.getName())) {
+            return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
+                    : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
+                            + EEFPropertyViewUtil.spaceFormat(propertyName)
+                            + EEFPropertyViewUtil.spaceFormat(valueLiteral);
+        } else if (valueType.equalsIgnoreCase(CommandPropertyValueType.MESSAGE_ELEMENT.getName())) {
+            if (((CommandProperty) object).getValueMessageElementXpath() != null) {
+                String valueMessageXpath = ((CommandProperty) object).getValueMessageElementXpath().toString();
+                return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
+                        : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
+                                + EEFPropertyViewUtil.spaceFormat(propertyName)
+                                + EEFPropertyViewUtil.spaceFormat(valueMessageXpath);
+            } else
+                return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
+                        : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
+                                + EEFPropertyViewUtil.spaceFormat(propertyName);
+        } else
+            return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
+                    : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
+                            + EEFPropertyViewUtil.spaceFormat(propertyName)
+                            + EEFPropertyViewUtil.spaceFormat(valueContextProperty);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Adding Command mediator key-value details to its property view. 
This is part of the fix to issue #3621

