### PR TITLE
Add EJB Mediator key-value details to its property view

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CommandPropertyItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CommandPropertyItemProvider.java
@@ -9,6 +9,7 @@ package org.wso2.developerstudio.eclipse.gmf.esb.provider;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang.WordUtils;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 
@@ -259,6 +260,7 @@ public class CommandPropertyItemProvider extends ItemProviderAdapter implements 
     @Override
     public String getText(Object object) {
         String propertyName = ((CommandProperty) object).getPropertyName();
+        String propertyNameLabel = WordUtils.abbreviate(propertyName.toString(), 8, 10, " ...");
         String valueType = ((CommandProperty) object).getValueType().toString();
         String valueLiteral = ((CommandProperty) object).getValueLiteral();
         String valueContextProperty = ((CommandProperty) object).getValueContextPropertyName().toString();
@@ -266,14 +268,14 @@ public class CommandPropertyItemProvider extends ItemProviderAdapter implements 
         if (valueType.equalsIgnoreCase(CommandPropertyValueType.LITERAL.getName())) {
             return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
                     : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
-                            + EEFPropertyViewUtil.spaceFormat(propertyName)
+                            + EEFPropertyViewUtil.spaceFormat(propertyNameLabel)
                             + EEFPropertyViewUtil.spaceFormat(valueLiteral);
         } else if (valueType.equalsIgnoreCase(CommandPropertyValueType.MESSAGE_ELEMENT.getName())) {
             if (((CommandProperty) object).getValueMessageElementXpath() != null) {
                 String valueMessageXpath = ((CommandProperty) object).getValueMessageElementXpath().toString();
                 return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
                         : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
-                                + EEFPropertyViewUtil.spaceFormat(propertyName)
+                                + EEFPropertyViewUtil.spaceFormat(propertyNameLabel)
                                 + EEFPropertyViewUtil.spaceFormat(valueMessageXpath);
             } else
                 return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
@@ -282,7 +284,7 @@ public class CommandPropertyItemProvider extends ItemProviderAdapter implements 
         } else
             return propertyName == null || propertyName.length() == 0 ? getString("_UI_CommandProperty_type")
                     : EEFPropertyViewUtil.spaceFormat(getString("_UI_CommandProperty_type"))
-                            + EEFPropertyViewUtil.spaceFormat(propertyName)
+                            + EEFPropertyViewUtil.spaceFormat(propertyNameLabel)
                             + EEFPropertyViewUtil.spaceFormat(valueContextProperty);
     }
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/MethodArgumentItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/MethodArgumentItemProvider.java
@@ -18,6 +18,7 @@ package org.wso2.developerstudio.eclipse.gmf.esb.provider;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang.WordUtils;
 import org.eclipse.emf.common.notify.AdapterFactory;
 import org.eclipse.emf.common.notify.Notification;
 
@@ -29,6 +30,8 @@ import org.eclipse.emf.edit.provider.IStructuredItemContentProvider;
 import org.eclipse.emf.edit.provider.ITreeItemContentProvider;
 
 import org.wso2.developerstudio.eclipse.gmf.esb.MethodArgument;
+import org.wso2.developerstudio.eclipse.gmf.esb.PropertyValueType;
+import org.wso2.developerstudio.eclipse.gmf.esb.presentation.EEFPropertyViewUtil;
 
 /**
  * This is the item provider adapter for a {@link org.wso2.developerstudio.eclipse.gmf.esb.MethodArgument} object.
@@ -77,14 +80,26 @@ public class MethodArgumentItemProvider extends AbstractNameValueExpressionPrope
      * This returns the label text for the adapted class.
      * <!-- begin-user-doc -->
      * <!-- end-user-doc -->
-     * @generated
+     * @generated NOT
      */
     @Override
     public String getText(Object object) {
-        String label = ((MethodArgument)object).getPropertyName();
-        return label == null || label.length() == 0 ?
-            getString("_UI_MethodArgument_type") :
-            getString("_UI_MethodArgument_type") + " " + label;
+        String propertyName = ((MethodArgument) object).getPropertyName();
+        String propertyNameLabel = WordUtils.abbreviate(propertyName.toString(), 18, 20, " ...");
+        String propertyValueType = ((MethodArgument) object).getPropertyValueType().toString();
+        String propertyValue = ((MethodArgument) object).getPropertyValue();
+        String propertyExpression = ((MethodArgument) object).getPropertyExpression().toString();
+
+        if (propertyValueType.equalsIgnoreCase(PropertyValueType.LITERAL.getName())) {
+            return propertyName == null || propertyName.length() == 0 ? getString("_UI_MethodArgument_type")
+                    : EEFPropertyViewUtil.spaceFormat(getString("_UI_MethodArgument_type"))
+                            + EEFPropertyViewUtil.spaceFormat(propertyNameLabel)
+                            + EEFPropertyViewUtil.spaceFormat(propertyValue);
+        } else
+            return propertyName == null || propertyName.length() == 0 ? getString("_UI_MethodArgument_type")
+                    : EEFPropertyViewUtil.spaceFormat(getString("_UI_MethodArgument_type"))
+                            + EEFPropertyViewUtil.spaceFormat(propertyNameLabel)
+                            + EEFPropertyViewUtil.spaceFormat(propertyExpression);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Adding EJB mediator key-value details to its property view.
This is part of the fix to issue #3621

