### PR TITLE
Fix load input button click issue when diagram start

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
@@ -159,11 +159,11 @@ public class DataMapperDiagramEditor extends DiagramDocumentEditor implements IG
         final IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
         try {
             workbench.showPerspective(DATA_MAPPER_PERSPECTIVE, window); // $NON-NLS-1$
-            PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+            PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
                 @Override
                 public void run() {
-                    try {
-                        loadInitialConfigFileLocations();
+                   try {
+                        //loadInitialConfigFileLocations();
                         realtimeDatamapperView = (RealtimeDatamapperView) PlatformUI.getWorkbench()
                                 .getActiveWorkbenchWindow().getActivePage().showView(DATA_MAPPER_TEST_VIEW);
                         realtimeDatamapperView.setURL();
@@ -232,7 +232,7 @@ public class DataMapperDiagramEditor extends DiagramDocumentEditor implements IG
 	
     // Show datamapper test window and reload web page.
     private void reloadDataMapperTestWindow() {
-        PlatformUI.getWorkbench().getDisplay().asyncExec(new Runnable() {
+        PlatformUI.getWorkbench().getDisplay().syncExec(new Runnable() {
             @Override
             public void run() {
                 try {


### PR DESCRIPTION
## Purpose
When a data mapper diagram is open, buttons in the diagram gets unresponsive for sometime(Until the realtime mapper also loads through the UI thread) this fixes the issue.