### PR TITLE
Fix issue with input data in realtime data mapping

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
@@ -621,7 +621,7 @@ public class DataMapperDiagramEditor extends DiagramDocumentEditor implements IG
                     Files.readAllBytes(Paths.get(DataMapperConfigHolder.getInstance().getInputSchemaPath())));
             JSONObject prevSchemaJson = (JSONObject) new JSONParser().parse(prevSchema);
             JSONObject modifiedSchemaJson = (JSONObject) new JSONParser().parse(modifiedSchema);
-            modifiedSchemaJson = (JSONObject) new JSONParser().parse(modifiedSchema);
+            prevSchemaJson.remove("inputType");
 
             // Compare whether the schema has any changes
             if (prevSchemaJson != null && modifiedSchema != null && !prevSchemaJson.equals(modifiedSchemaJson)) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper/src/org/wso2/developerstudio/datamapper/servlets/RegistryReaderServlet.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper/src/org/wso2/developerstudio/datamapper/servlets/RegistryReaderServlet.java
@@ -37,7 +37,6 @@ import org.eclipse.ui.PlatformUI;
 import org.wso2.developerstudio.datamapper.servlets.Utils.DatamapperUtils;
 
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 /**
  * This is the servlet used to serve requests coming from Datamapper test window.


### PR DESCRIPTION
## Purpose
> Input data changed to default values when a data was mapped without schema changes. 

## Approach
> The fix was to compare schema changes excluding the inputType field.