### PR TITLE
Fix saving file on close

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbMultiPageEditor.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbMultiPageEditor.java
@@ -1093,7 +1093,7 @@ public class EsbMultiPageEditor extends MultiPageEditorPart implements IGotoMark
         getEditor(0).doSave(monitor);
         // Since Complex endpoint type editors dose not have assiociated xml
         // file do not need to call this.
-        Display.getDefault().asyncExec(new Runnable() {
+        Display.getDefault().syncExec(new Runnable() {
             @Override
             public void run() {
                 try {


### PR DESCRIPTION
## Purpose
> Resolves [#2712](https://github.com/wso2/product-ei/issues/2712).

## Goals
> Fixes the issue of not saving unsaved files on closing although the save option is selected.

## Approach
> The issue was caused by the editor being closed before the XML is updated. Hence the XML should be updated synchronously. 