### PR TITLE
Check if input sample exists before comparing the schema

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
@@ -617,15 +617,17 @@ public class DataMapperDiagramEditor extends DiagramDocumentEditor implements IG
      */
     private boolean hasInputSchemaChanged(String modifiedSchema) {
         try {
-            String prevSchema = new String(
-                    Files.readAllBytes(Paths.get(DataMapperConfigHolder.getInstance().getInputSchemaPath())));
-            JSONObject prevSchemaJson = (JSONObject) new JSONParser().parse(prevSchema);
-            JSONObject modifiedSchemaJson = (JSONObject) new JSONParser().parse(modifiedSchema);
-            prevSchemaJson.remove("inputType");
+            if (null != DataMapperConfigHolder.getInstance().getInputSchemaPath()) {
+                String prevSchema = new String(
+                        Files.readAllBytes(Paths.get(DataMapperConfigHolder.getInstance().getInputSchemaPath())));
+                JSONObject prevSchemaJson = (JSONObject) new JSONParser().parse(prevSchema);
+                JSONObject modifiedSchemaJson = (JSONObject) new JSONParser().parse(modifiedSchema);
+                prevSchemaJson.remove("inputType");
 
-            // Compare whether the schema has any changes
-            if (prevSchemaJson != null && modifiedSchema != null && !prevSchemaJson.equals(modifiedSchemaJson)) {
-                return true;
+                // Compare whether the schema has any changes
+                if (prevSchemaJson != null && modifiedSchema != null && !prevSchemaJson.equals(modifiedSchemaJson)) {
+                    return true;
+                }
             }
         } catch (ParseException | IOException e) {
             log.error("Failed to compare schema!");


### PR DESCRIPTION
## Purpose
> Check if input sample exists before comparing the schema to decide whether the input data for the real-time datamapper should be loaded from the input sample or default values should be generated.