### PR TITLE
Make sure that all ForLoop names are unique

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/generator/ForLoopBean.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/generator/ForLoopBean.java
@@ -47,7 +47,7 @@ public class ForLoopBean {
 		arrayVariableListToInstantiate = new ArrayList<>();
 		objectVariableListToInstantiate = new ArrayList<>();
 		nullableVarialesList = new HashSet<>();
-		this.iterativeName = getValidIterateName(iterativeName);
+		this.iterativeName = getValidIterateName(iterativeName + "_" + java.util.UUID.randomUUID());
 		this.variableName = variableName;
 	}
 
@@ -57,7 +57,7 @@ public class ForLoopBean {
 		arrayVariableListToInstantiate = new ArrayList<>();
 		objectVariableListToInstantiate = new ArrayList<>();
 		this.nullableVarialesList = nullableVariableList;
-		this.iterativeName = getValidIterateName(iterativeName);
+		this.iterativeName = getValidIterateName(iterativeName + "_" + java.util.UUID.randomUUID());
 		this.variableName = variableName;
 	}
 


### PR DESCRIPTION
## Purpose
Fix the Datamapper when there's two lists with the same name in the input schema that are mapped to the output schema.

For example, if we have the following structure :
```
{} Person
    {} Addresses
        [] string
    {} Titles
        [] string
```

Currently, the Datamapper will generate the following javascript code :
```
map_S_Person_S_root = function(){ 
var outputroot={};

var count_i_string = 0;
var count_i_string = 0;
outputroot =  {};
outputroot.Person =  {};
outputroot.Person.Addresses =  [];
outputroot.Person.Titles =  [];

for(i_string in inputPerson.Addresses.string){
    outputroot.Addresses[count_i_string] = 0+inputPerson.Addresses.string[i_string];
    count_i_string++;
}

for(i_string in inputPerson.Titles.string){
    outputroot.Titles[count_i_string] = inputPerson.Titles.string[i_string]);
    count_i_string++;
}
return outputroot;
};
```

As can be seen, the two loops will use and increment the same variable name. The first array will be correctly filled, but the second array will be empty (or incorrectly filled) because the counted is not reinitialized.

## Goals
Each ForLoop is added to a list of mappings (forLoopBeanList) where they have the same parent (called root). So, there's no way to create a unique name for each counter.

The following pull request add a unique identifier to each ForLoopBean by using a randomly generated string.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.
