### PR TITLE
Make expression selector window resizable in Integration Studio 6.5.0

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFNameSpacedPropertyEditorDialog.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFNameSpacedPropertyEditorDialog.java
@@ -517,7 +517,7 @@ public class EEFNameSpacedPropertyEditorDialog extends Dialog {
      */
     public NamespacedProperty open() {
         Shell parentShell = getParent();
-        dialogShell = new Shell(parentShell, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        dialogShell = new Shell(parentShell, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL | SWT.RESIZE);
 
         // Configure dialog shell internal layout.
         FormLayout dialogShellLayout = new FormLayout();
@@ -1024,9 +1024,9 @@ public class EEFNameSpacedPropertyEditorDialog extends Dialog {
         dialogShell.layout();
         dialogShell.pack();
         if (operatingSystemType.indexOf(OS_TYPE_WINDOWS) >= 0) {
-            dialogShell.setSize(1050, 870);
+            dialogShell.setSize(1050, 770);
         } else {
-            dialogShell.setSize(1050, 800);
+            dialogShell.setSize(1050, 700);
         }
         centerDialog();
         dialogShell.open();


### PR DESCRIPTION
Making expression selector window resizeable in Integration Studio 6.5.0.

Fixes: wso2/product-ei#4398