### PR TITLE
Add support for selecting templates as supportive artifacts in test suites

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/src/org/wso2/developerstudio/eclipse/esb/dashboard/templates/wizard/ProjectCreationUtil.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.dashboard.templates/src/org/wso2/developerstudio/eclipse/esb/dashboard/templates/wizard/ProjectCreationUtil.java
@@ -791,7 +791,7 @@ public class ProjectCreationUtil {
         try {
             MavenProject mavenProject = MavenUtils.getMavenProject(pomFile);
             Plugin unitTestPlugin = MavenUtils.createPluginEntry(mavenProject, "org.wso2.maven",
-                    "synapse-unit-test-maven-plugin", "5.2.10", false);
+                    "synapse-unit-test-maven-plugin", "5.2.17", false);
 
             PluginExecution pluginExecution = new PluginExecution();
             pluginExecution.addGoal("synapse-unit-test");

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
@@ -179,7 +179,7 @@ public class ESBProjectWizard extends AbstractWSO2ProjectCreationWizard {
         try {
             MavenProject mavenProject = MavenUtils.getMavenProject(pomFile);
             Plugin unitTestPlugin = MavenUtils.createPluginEntry(mavenProject, "org.wso2.maven",
-                    "synapse-unit-test-maven-plugin", "5.2.10", false);
+                    "synapse-unit-test-maven-plugin", "5.2.17", false);
 
             PluginExecution pluginExecution = new PluginExecution();
             pluginExecution.addGoal("synapse-unit-test");

--- a/plugins/org.wso2.developerstudio.eclipse.esb.synapse.unit.test/src/org/wso2/developerstudio/eclipse/esb/synapse/unit/test/component/DependencyTree.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.synapse.unit.test/src/org/wso2/developerstudio/eclipse/esb/synapse/unit/test/component/DependencyTree.java
@@ -77,7 +77,7 @@ public class DependencyTree {
 
     private String[] acceptTestArtifactFolders = { "api", "sequences", "proxy-services" };
     private String[] acceptSupportiveArtifactFolders = { "api", "proxy-services", "sequences", "endpoints",
-            "local-entries" };
+            "local-entries", "templates" };
     private String childTreeItemIcon = "/icons/artifact.png";
     private String parentTreeItemIcon = "/icons/root-folder.png";
     private String parentRegistryTreeItemIcon = "/icons/registry_project.png";

--- a/plugins/org.wso2.developerstudio.eclipse.esb.synapse.unit.test/src/org/wso2/developerstudio/eclipse/esb/synapse/unit/test/wizard/unittest/UnitTestSuiteSupportiveArtifactsSelectionPage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.synapse.unit.test/src/org/wso2/developerstudio/eclipse/esb/synapse/unit/test/wizard/unittest/UnitTestSuiteSupportiveArtifactsSelectionPage.java
@@ -17,18 +17,23 @@
  */
 package org.wso2.developerstudio.eclipse.esb.synapse.unit.test.wizard.unittest;
 
+import java.io.File;
+
 import org.eclipse.jface.wizard.WizardPage;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.graphics.Color;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 import org.wso2.developerstudio.eclipse.esb.synapse.unit.test.component.DependencyTree;
@@ -65,10 +70,21 @@ public class UnitTestSuiteSupportiveArtifactsSelectionPage extends WizardPage {
         setControl(container);
 
         container.setLayout(new FormLayout());
+        
+        //Specific for the release 7.0.2 
+        Label templateNotice = new Label(container, SWT.NONE);
+        final Color myColor = new Color(Display.getCurrent(), 244, 41, 65);
+        templateNotice.setText("Notice : Take the WSO2 Micro-Integrator latest WUM updated pack to work with template testing in Unit Test Suite.");
+        templateNotice.setForeground(myColor);
+        FormData fd = new FormData();
+        fd.top = new FormAttachment(1);
+        fd.left = new FormAttachment(2);
+        templateNotice.setLayoutData(fd);
+        templateNotice.setVisible(false);
 
         Label supportiveArtifactlblName = new Label(container, SWT.NONE);
-        FormData fd = new FormData();
-        fd.top = new FormAttachment(5);
+        fd = new FormData();
+        fd.top = new FormAttachment(templateNotice, 2);
         fd.left = new FormAttachment(2);
         supportiveArtifactlblName.setLayoutData(fd);
         supportiveArtifactlblName.setText(SUPPORTIVE_ARTIFACTS_LABEL);
@@ -88,6 +104,10 @@ public class UnitTestSuiteSupportiveArtifactsSelectionPage extends WizardPage {
                 final TreeItem item = (TreeItem) evt.item;
                 if (evt.detail == SWT.CHECK && item != null) {
                     resourceTree.handleTreeItemChecked(item);
+					if (item.getText(1).contains("src" + File.separator + "main" + File.separator + "synapse-config"
+							+ File.separator + "templates")) {
+						templateNotice.setVisible(true);
+					}
                 }
             }
 

--- a/plugins/org.wso2.developerstudio.esb.form.editors/src/org/wso2/developerstudio/esb/form/editors/unittest/SynapseUnitTestFormPage.java
+++ b/plugins/org.wso2.developerstudio.esb.form.editors/src/org/wso2/developerstudio/esb/form/editors/unittest/SynapseUnitTestFormPage.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.developerstudio.esb.form.editors.unittest;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -39,6 +40,7 @@ import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.FormLayout;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
@@ -130,7 +132,7 @@ public class SynapseUnitTestFormPage extends AbstractEsbFormPage {
         referenceTable = new ReferenceTable();
         refreshMockServicesButton = referenceTable.createRefreshButton(body, "", SWT.PUSH);
         FormData data = new FormData();
-        data.top = new FormAttachment(1);
+        data.top = new FormAttachment(2);
         data.right = new FormAttachment(97);
         refreshMockServicesButton.setLayoutData(data);
 
@@ -183,10 +185,21 @@ public class SynapseUnitTestFormPage extends AbstractEsbFormPage {
         data.right = new FormAttachment(98);
         artifactsDetailSection.setLayoutData(data);
         artifactsDetailSection.setClient(artifactSectionClient);
+        
+        //Specific for the release 7.0.2 
+        Label templateNotice = new Label(artifactSectionClient, SWT.NONE);
+        final Color myColor = new Color(Display.getCurrent(), 244, 41, 65);
+        templateNotice.setText("Notice : Take the WSO2 Micro-Integrator latest WUM updated pack to work with template testing in Unit Test Suite.");
+        templateNotice.setForeground(myColor);
+        FormData fd = new FormData();
+        fd.top = new FormAttachment(artifactSectionClient, 5);
+        fd.left = new FormAttachment(1);
+        templateNotice.setLayoutData(fd);
+        templateNotice.setVisible(false);
 
         Label supportiveArtifactlblName = new Label(artifactSectionClient, SWT.NONE);
         data = new FormData();
-        data.top = new FormAttachment(artifactSectionClient, 10);
+        data.top = new FormAttachment(templateNotice, 7);
         data.left = new FormAttachment(1);
         data.right = new FormAttachment(99);
         supportiveArtifactlblName.setLayoutData(data);
@@ -212,6 +225,10 @@ public class SynapseUnitTestFormPage extends AbstractEsbFormPage {
                     setSave(true);
                     updateDirtyState();
                     resourceTree.handleTreeItemChecked(item);
+                    if (item.getText(1).contains("src" + File.separator + "main" + File.separator + "synapse-config"
+                            + File.separator + "templates")) {
+                        templateNotice.setVisible(true);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Purpose
> This PR is related to add support for selecting templates as supportive artifacts in test suites and upgrade the unit testing plugin version.