### PR TITLE
Fix: Issue 899

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXML.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXML.java
@@ -94,7 +94,7 @@ public class SchemaGeneratorForXML extends SchemaGeneratorForJSON implements ISc
 		return getSchemaContent(entireFileText, type, null);
 	}
 
-	private String replaceAttributesWithElements(String entireFileText) throws IOException {
+	protected String replaceAttributesWithElements(String entireFileText) throws IOException {
 		try {
 			OMElement element = AXIOMUtil.stringToOM(entireFileText);
 			OMFactory factory = OMAbstractFactory.getOMFactory();

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXSD.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaGeneratorForXSD.java
@@ -57,6 +57,8 @@ public class SchemaGeneratorForXSD extends AbstractSchemaGenerator implements IS
 				if (generatedXMLContent != null) {
 					String xmlSchemaContent = XML_VERSION_1_0_ENCODING_UTF_8 + generatedXMLContent;
 					SchemaGeneratorForXML schemaGeneratorForXML = new SchemaGeneratorForXML();
+					// Replacing attributes with elements because SchemaGeneratorForXML requires so.
+					xmlSchemaContent = schemaGeneratorForXML.replaceAttributesWithElements(xmlSchemaContent);
 					schemaContent = schemaGeneratorForXML.getSchemaContent(xmlSchemaContent, FileType.XML, null);
 				}
 				deleteRegResourcesCreated(xsdRegResource);

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/XSD2XMLGenerator.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/XSD2XMLGenerator.java
@@ -57,6 +57,7 @@ import org.eclipse.xsd.XSDSchema;
 import org.eclipse.xsd.XSDSimpleTypeDefinition;
 import org.eclipse.xsd.XSDTypeDefinition;
 import org.eclipse.xsd.impl.XSDElementDeclarationImpl;
+import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -535,6 +536,27 @@ public class XSD2XMLGenerator extends NewXMLGenerator {
 			return document.createTextNode(value);
 		}
 		
+		/* (non-Javadoc)
+		 * Method in the super class create an attribute element.
+		 * If type of the attribute is string, it sets attribute element value to "".
+		 * Then, attribute element type will be refer to as NULL when generating json schema.
+		 * To avoid that, this method set value to attribute name if value is empty.
+		 *
+		 * @see org.eclipse.wst.xml.core.internal.contentmodel.util.DOMContentBuilderImpl#visitCMAttributeDeclaration(org.eclipse.wst.xml.core.internal.contentmodel.CMAttributeDeclaration)
+		 */
+		@Override
+		public void visitCMAttributeDeclaration(CMAttributeDeclaration ad) {
+			super.visitCMAttributeDeclaration(ad);
+			int size = currentParent.getAttributes().getLength();
+			if (size > 0) {
+				Attr attr = (Attr) currentParent.getAttributes()
+						.item(currentParent.getAttributes().getLength() - 1);
+				if (attr.getValue().isEmpty()) {
+					attr.setValue(attr.getName());
+				}
+			}
+		}
+
 		/**
 		 * This was stolen directly from XSDImpl. It builds a list of the enumeration
 		 * values for the given XSD type definition.


### PR DESCRIPTION
XSD schemas are first converted to XML before generating JSON schemas. XML-2-JSON conversion requires XML attributes to be represented as <@attrname/> elements instead of inner properties.
Thus, attributes were changed to element after generating XML from the XSD.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/899