### PR TITLE
Fix: Issue 902

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/XSLTGenerator.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/XSLTGenerator.java
@@ -362,8 +362,11 @@ public class XSLTGenerator {
                         } else if (node.getInNode().getOutNodes().size() > 0) {
                             Element valueOfElement = outputXMLFile.getDocument().createElement(XSL_VALUE_OF);
                             currentElement.appendChild(valueOfElement);
-                            valueOfElement.setAttribute(SELECT,
-                                    getValueFromMapping(node.getInNode().getOutNodes().get(0)));
+                            String path = getValueFromMapping(node.getInNode().getOutNodes().get(0));
+                            if (path.equals(EMPTY_STRING)) {
+                                path = ".";
+                            }
+                            valueOfElement.setAttribute(SELECT, path);
                         }
                     }
                 } else if (!node.getInNode().getOutNodes().isEmpty()) {


### PR DESCRIPTION
When mapping an array element(from input) to an array element(from output) directly, the select attribute becomes empty instead of "." or "text()". Check for empty string and replace with ".".

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/902