### PR TITLE
Search connector schema retrieval based on connector subcomponent name

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/CloudConnectorDirectoryTraverser.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/CloudConnectorDirectoryTraverser.java
@@ -223,7 +223,7 @@ public class CloudConnectorDirectoryTraverser {
             Component subComponent = new Component();
             subComponent.deserialize(artifactContent);
             for (SubComponents subComponents : subComponent.getSubComponents()) {
-                operationFileNamesMap.put(subComponents.getFileName(), dependency.getComponent());
+                operationFileNamesMap.put(subComponents.getName(), dependency.getComponent());
             }
         }
         return operationFileNamesMap;


### PR DESCRIPTION
## Purpose
Search connector schema retrieval based on subcomponent name. Earlier it was based on sub component file name.
Fix https://github.com/wso2/devstudio-tooling-ei/issues/919