### PR TITLE
Fix: Issue 924

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/XSLTGenerator.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/XSLTGenerator.java
@@ -39,11 +39,13 @@ import javax.xml.xpath.XPathFactory;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.ABSOLUTE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.ADD;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.AND;
+import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.APOSTROPHE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.ARRAY_TYPE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.AT_NODE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.AT_OPERATORS;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.BOOLEAN_TYPE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.CEILING;
+import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.COMMA;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.COMPARE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.CONCAT;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.CONSTANT;
@@ -51,6 +53,7 @@ import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGenera
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DEFAULT_NAME;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DEFAULT_SCOPE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DEFAULT_VALUE;
+import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DELIMITER;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DIVIDE;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.DOT_SYMBOL;
 import static org.wso2.developerstudio.datamapper.diagram.xslt.config.XSLTGeneratorConstants.EMPTY_STRING;
@@ -458,9 +461,16 @@ public class XSLTGenerator {
                 }
                 return "'" + operatorNode.getProperty("constantValue") + "'";
             case CONCAT:
-                if (operatorNode.getLeftContainer().getInNodes().size() == 2) {
-                    return "concat(" + getValueFromMapping(operatorNode.getLeftContainer().getInNodes().get(0)) + ","
-                            + getValueFromMapping(operatorNode.getLeftContainer().getInNodes().get(1)) + ")";
+                if (operatorNode.getLeftContainer().getInNodes().size() >= 2) {
+                    String delimiter = operatorNode.getProperty(DELIMITER) != null ? operatorNode.getProperty(DELIMITER)
+                            : " ";
+                    delimiter = APOSTROPHE + delimiter + APOSTROPHE;
+                    String value = "concat(" + getValueFromMapping(operatorNode.getLeftContainer().getInNodes().get(0));
+                    for (int i = 1; i < operatorNode.getLeftContainer().getInNodes().size(); i++) {
+                        value += COMMA + delimiter + COMMA
+                                + getValueFromMapping(operatorNode.getLeftContainer().getInNodes().get(i));
+                    }
+                    return value + ")";
                 }
                 break;
             case LOWERCASE:

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/config/XSLTGeneratorConstants.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/xslt/config/XSLTGeneratorConstants.java
@@ -120,6 +120,7 @@ public final class XSLTGeneratorConstants {
     public static final String LEFT_CONNECTORS = "leftConnectors";
     public static final String LEFT_CONTAINER = "leftContainer";
     public static final String BASIC_CONTAINER = "basicContainer";
+    public static final String DELIMITER = "delimiter";
 
     public static final String XMLNS_XSL = "xmlns:xsl";
     public static final String XMLNS_XS = "xmlns:xs";
@@ -155,4 +156,6 @@ public final class XSLTGeneratorConstants {
     public static final String NAMESPACE_GENERAL_PREFIX = "xmlns:";
     public static final String NAMESPACE_ATTRIBUTE_VALUE = "value";
 
+    public static final String APOSTROPHE = "'";
+    public static final String COMMA = ",";
 }


### PR DESCRIPTION
1. The XSLT stylesheet generator assumes that concat operator will have only two inputs and discards concat operators with more or less than 2 inputs. Changed it to handle 2 or more inputs.
2. Also, the generator did not consider the delimiter given by the concat operator which was also addressed in this fix.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/924