### PR TITLE
Update opened editors when removing connector from workspace

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/CloudConnectorImportWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/CloudConnectorImportWizard.java
@@ -125,6 +125,10 @@ public class CloudConnectorImportWizard extends AbstractWSO2ProjectCreationWizar
                         .getData()).getConnectorFilePath();
                 try {
                     FileUtils.deleteDirectory(new File(filePath));
+                    
+                    // Remove the archived connector.
+                    File zipFile = new File(filePath + ".zip");
+                    zipFile.delete();
                 } catch (IOException e) {
                     log.error("Error while deleting the connector : " + filePath, e);
                 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/EditorUtils.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/EditorUtils.java
@@ -867,6 +867,8 @@ public class EditorUtils {
                                 addCloudConnectorOperations(((EsbMultiPageEditor) editor).getGraphicalEditor(),
                                         esbPaletteFactory);
                             }
+                            removeNonExistingCloudConnectorOperations(
+                                    ((EsbMultiPageEditor) editor).getGraphicalEditor(), esbPaletteFactory);
                         } catch (Exception e) {
                             MessageDialog.openError(PlatformUI.getWorkbench().getDisplay().getActiveShell(),
                                     "Developer Studio Error Dialog",
@@ -907,6 +909,32 @@ public class EditorUtils {
             }
         }
 
+    }
+
+    /**
+     * This method removes connector palettes from editor if the connector is not in the workspace.
+     * 
+     * @param editorPart editor from which palettes should be removed
+     * @param esbPaletteFactory PaletteFactory of the editor
+     */
+    private static void removeNonExistingCloudConnectorOperations(EsbDiagramEditor editorPart,
+            EsbPaletteFactory esbPaletteFactory) {
+        EsbEditorInput input = (EsbEditorInput) editorPart.getEditorInput();
+        IFile file = input.getXmlResource();
+        IProject activeProject = file.getProject();
+        String connectorDirectory = activeProject.getWorkspace().getRoot().getLocation().toOSString() + File.separator
+                + CloudConnectorDirectoryTraverser.connectorPathFromWorkspace;
+        File directory = new File(connectorDirectory);
+        List<String> connectorDirectoryNames = new ArrayList<>();
+        if (directory.isDirectory()) {
+            File[] children = directory.listFiles();
+            for (int childIndex = 0; childIndex < children.length; ++childIndex) {
+                if (children[childIndex].isDirectory()) {
+                    connectorDirectoryNames.add(children[childIndex].getName());
+                }
+            }
+        }
+        esbPaletteFactory.removeNonExistingCloudConnectorOperations(editorPart, connectorDirectoryNames);
     }
 
     /**

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbPaletteFactory.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbPaletteFactory.java
@@ -93,6 +93,8 @@ import org.wso2.developerstudio.eclipse.logging.core.Logger;
 public class EsbPaletteFactory {
 
     public static final int INITIAL_STATE_OPEN = 0, INITIAL_STATE_CLOSED = 1, INITIAL_STATE_PINNED_OPEN = 2;
+    
+    private static final String CLOUD_CONNECTOR_PREFIX = "CloudConnector-";
 
     private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
 
@@ -1516,6 +1518,33 @@ public class EsbPaletteFactory {
                 container.add(createCloudConnector1CreationTool(names[i].split("-")[0],
                         names[i].split("-")[0] + "-cloudConnector", connectorPath + File.separator + names[i]
                                 + File.separator + "icon" + File.separator + icon_exsists));
+            }
+        }
+    }
+    
+    /**
+     * This method removes connector palettes from editor if the connector is not in the given list.
+     * 
+     * @param editor editor from which palettes should be removed
+     * @param connectorDirectoryNames list to be checked against
+     */
+    public void removeNonExistingCloudConnectorOperations(IEditorPart editor, List<String> connectorDirectoryNames) {
+        List<String> connectorNames = new ArrayList<>();
+        for (String connectorDirectoryName : connectorDirectoryNames) {
+            String connectorName = connectorDirectoryName.split("-")[0];
+            connectorNames.add(CLOUD_CONNECTOR_PREFIX + connectorName);
+        }
+
+        List<?> list = ((DiagramEditDomain) ((EsbDiagramEditor) editor).getDiagramEditDomain()).getPaletteViewer()
+                .getPaletteRoot().getChildren();
+        for (int palleteIndex = 0; palleteIndex < list.size(); ++palleteIndex) {
+            if (list.get(palleteIndex) instanceof PaletteDrawer) {
+                String peletteId = ((PaletteDrawer) list.get(palleteIndex)).getId();
+                if (peletteId.startsWith(CLOUD_CONNECTOR_PREFIX) && !connectorNames.contains(peletteId)) {
+                    ((DiagramEditDomain) ((EsbDiagramEditor) editor).getDiagramEditDomain()).getPaletteViewer()
+                            .getPaletteRoot().remove((PaletteDrawer) list.get(palleteIndex));
+                    palleteIndex--;
+                }
             }
         }
     }


### PR DESCRIPTION
When removing connectors from projects,
    1. Remove relevant archived connector from the workspace.
    2. Remove relevant connector pallets from opened editors.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/970