### PR TITLE
Fix: Issue 959

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/.classpath
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/.classpath
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-core_2.6.1.wso2v1.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-databind_2.6.1.wso2v3.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/jackson-dataformat-yaml-2.9.2.jar"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/META-INF/MANIFEST.MF
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/META-INF/MANIFEST.MF
@@ -25,8 +25,5 @@ Import-Package: org.codehaus.jettison.json;version="1.3.4.wso2v1",
  org.wso2.developerstudio.eclipse.general.project.artifact.bean;version="7.0.0",
  org.wso2.developerstudio.eclipse.general.project.utils;version="7.0.0",
  org.wso2.developerstudio.eclipse.gmf.esb,
- org.wso2.developerstudio.eclipse.registry.core.utils;version="7.0.0"
-Bundle-ClassPath: lib/jackson-core_2.6.1.wso2v1.jar,
- lib/jackson-databind_2.6.1.wso2v3.jar,
- lib/jackson-dataformat-yaml-2.9.2.jar,
- .
+ org.wso2.developerstudio.eclipse.registry.core.utils;version="7.0.0",
+ org.yaml.snakeyaml

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/build.properties
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/build.properties
@@ -1,11 +1,6 @@
-source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
-               .,\
                plugin.xml,\
                project_wizard.xml,\
                icons/synapseAPI.gif,\
-               icons/synapseAPILarge.png,\
-               lib/jackson-core_2.6.1.wso2v1.jar,\
-               lib/jackson-databind_2.6.1.wso2v3.jar,\
-               lib/jackson-dataformat-yaml-2.9.2.jar
+               icons/synapseAPILarge.png

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/src/org/wso2/developerstudio/eclipse/artifact/synapse/api/ui/wizard/SynapseAPICreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/src/org/wso2/developerstudio/eclipse/artifact/synapse/api/ui/wizard/SynapseAPICreationWizard.java
@@ -49,6 +49,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.json.simple.JSONValue;
 import org.wso2.carbon.rest.api.APIException;
 import org.wso2.carbon.rest.api.service.RestApiAdmin;
 import org.wso2.developerstudio.eclipse.artifact.synapse.api.Activator;
@@ -77,9 +78,7 @@ import org.wso2.developerstudio.eclipse.registry.core.utils.RegistryResourceInfo
 import org.wso2.developerstudio.eclipse.registry.core.utils.RegistryResourceUtils;
 import org.wso2.developerstudio.eclipse.utils.file.FileUtils;
 import org.wso2.developerstudio.eclipse.utils.project.ProjectUtils;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.yaml.snakeyaml.Yaml;
 
 
 /**
@@ -307,20 +306,16 @@ public class SynapseAPICreationWizard extends AbstractWSO2ProjectCreationWizard 
 		return artifact;
 	}
 
-	public static String convertYamlToJson(String yaml) {
-		YAMLFactory yamlFactory = new YAMLFactory();
-		ObjectMapper yamlReader = new ObjectMapper(yamlFactory);
-		String convertedJSON = "";
-		try {
-			Object tmpYamlValueObject = yamlReader.readValue(yaml, Object.class);
-			ObjectMapper jsonWriter = new ObjectMapper();
-			convertedJSON = jsonWriter.writeValueAsString(tmpYamlValueObject);
-		} catch (IOException e) {
-			log.error("Error occured while trying to read yaml file", e);
-		} catch (Exception e) {
-			log.error("Error occured while trying to convert yaml file to json file", e);
-		}
-		return convertedJSON;
+	/**
+	 * Converts a given YAML content to JSON.
+	 * 
+	 * @param yamlSource yaml content
+	 * @return converted JSON content
+	 */
+	public static String convertYamlToJson(String yamlSource) {
+		Yaml yaml = new Yaml();
+		Object object = yaml.load(yamlSource);
+		return JSONValue.toJSONString(object);
 	}
 
 	private String getSwaggerFileAsJSON(File swaggerFile) {


### PR DESCRIPTION
**Issue:** Cannot create Synapse APIs from YAML swagger files because as an intermediate step YAML gets converted to JSON and it fails to load the library related to this conversion.

**Fix:** Change the conversion method so that it uses a different library.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/959