### PR TITLE
Validation when creating synapse API

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/src/org/wso2/developerstudio/eclipse/artifact/synapse/api/exceptions/SwaggerDefinitionProcessingException.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.synapse.api/src/org/wso2/developerstudio/eclipse/artifact/synapse/api/exceptions/SwaggerDefinitionProcessingException.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+
+ *      http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.developerstudio.eclipse.artifact.synapse.api.exceptions;
+
+/**
+ * Exception thrown when processing swagger definition.
+ */
+public class SwaggerDefinitionProcessingException extends Exception {
+    public SwaggerDefinitionProcessingException() {
+        super();
+    }
+
+    public SwaggerDefinitionProcessingException(String message) {
+        super(message);
+    }
+
+    public SwaggerDefinitionProcessingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SwaggerDefinitionProcessingException(Throwable cause) {
+        super(cause);
+    }
+
+    protected SwaggerDefinitionProcessingException(String message, Throwable cause, boolean enableSuppression,
+            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
When creating a synapse API using a swagger definition,
1. Allow only if both the registry project and definition file are selected.
2. Show error message when an invalid swagger file is used.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/960