### PR TITLE
Allow creating an Integration project without the config project

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/model/ESBSolutionProjectModel.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/model/ESBSolutionProjectModel.java
@@ -165,9 +165,6 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
             setEsbProjectName(data.toString());
         } else if (key.equals(ESB_PROJECT_CHOICE)) {
             setConfigProjectChecked((boolean) data);
-            if (!this.isConfigProjectChecked) {
-                setEsbProjectName("");
-            }
         } else if (key.equals(MMM_PROJECT_CHOICE)) {
             setMMMProjectChecked((boolean) data);
             setEsbProjectName(getMMMProjectName());
@@ -184,31 +181,16 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
             setKubernetesExporterProjectName(data.toString());
         } else if (key.equals(REGISTRY_PROJECT_CHECKED)) {
             setRegistryProjectChecked((boolean) data);
-            if (!this.registryProjectChecked) {
-                setRegistryProjectName("");
-            }
         } else if (key.equals(CONNECTOR_EXPORTER_PROJECT_CHECKED)) {
             setConnectorExporterProjectChecked((boolean) data);
-            if (!this.connectorExporterProjectChecked) {
-                setConnectorExporterProjectName("");
-            }
         } else if (key.equals(CAPP_PROJECT_CHECKED)) {
             setCappProjectChecked((boolean) data);
-            if (!this.cappProjectChecked) {
-                setCompositeApplicationProjectName("");
-            }
         } else if (key.equals(DOCKER_EXPORTER_PROJECT_CHECKED)) {
             setDockerExporterProjectChecked((boolean) data);
             returnResult = (boolean) data;
-            if (!this.isDockerExporterProjectChecked()) {
-                setDockerExporterProjectName("");
-            }
         } else if (key.equals(KUBERNETES_EXPORTER_PROJECT_CHECKED)) {
             setKubernetesExporterProjectChecked((boolean) data);
             returnResult = (boolean) data;
-            if (!this.isKubernetesExporterProjectChecked()) {
-                setKubernetesExporterProjectName("");
-            }
         }
 
         return returnResult;

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
@@ -130,9 +130,7 @@ public class ESBProjectWizard extends AbstractWSO2ProjectCreationWizard {
 	}
 	
 	public File getPomFile() {
-		File updatedFile = pomfile;
-		return updatedFile;
-
+		return pomfile;
 	}
 	
 	public static void openEditor(File file,Map<File,String> fileList){

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBSolutionProjectCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBSolutionProjectCreationWizard.java
@@ -133,6 +133,7 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
 				mmmModel.setSelectedWorkingSets(esbSolutionProjectModel.getSelectedWorkingSets());
 				mmmWizard.performFinish();
 				projectRootPath = projectRootPath + File.separator + mmmProjectName;
+				pomFile = mmmWizard.getPomFile();
 			} catch (ObserverFailedException e) {
 				log.error("Failed to set project name : " + mmmProjectName, e);
 			}
@@ -153,7 +154,9 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
 			}
 			esbProjectWizard.setModel(esbSolutionProjectModel);
 			esbProjectWizard.performFinish();
-			pomFile = esbProjectWizard.getPomFile();
+			if (!isMMMChecked) {
+				pomFile = esbProjectWizard.getPomFile();
+			}
 		}
 		
 		// Creating Registry Project
@@ -272,8 +275,7 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
 				distributionModel.setProjectName(distributionProjectName);
 				distributionModel.setLocation(new File(projectRootPath + File.separator + distributionProjectName));
 				distributionModel.setIsUserDefine(esbSolutionProjectModel.isUserSet());
-				distributionModel.setLocation(esbSolutionProjectModel.getLocation());
-				updateMavenInformation(pomFile,CAPP_ARTIFACT_ID);
+				updateMavenInformation(pomFile, CAPP_ARTIFACT_ID);
 				distributionModel.setGroupId(esbSolutionProjectModel.getGroupId());
 				distributionModel.setMavenInfo(esbSolutionProjectModel.getMavenInfo());
 				distributionModel.setSelectedOption(esbSolutionProjectModel.getSelectedOption());
@@ -305,7 +307,7 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
 	private void updateMavenInformation(File pomLocation, String name) {
 		MavenProject mavenProject = getMavenProject(pomLocation);
 		esbSolutionProjectModel.getMavenInfo().setGroupId(mavenProject.getGroupId());
-		esbSolutionProjectModel.getMavenInfo().setArtifactId(mavenProject.getArtifactId()+name);
+		esbSolutionProjectModel.getMavenInfo().setArtifactId(mavenProject.getArtifactId() + name);
 		esbSolutionProjectModel.getMavenInfo().setVersion(mavenProject.getVersion());
 	}
 


### PR DESCRIPTION
## Purpose
Allow unselecting Config project while creating the Integration project.

Related issue https://github.com/wso2/devstudio-tooling-ei/issues/1011