### PR TITLE
Fix: Set project nature before project creation.

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.connector/src/org/wso2/developerstudio/eclipse/artifact/connector/ui/wizard/ConnectorCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.connector/src/org/wso2/developerstudio/eclipse/artifact/connector/ui/wizard/ConnectorCreationWizard.java
@@ -83,6 +83,7 @@ public class ConnectorCreationWizard extends AbstractWSO2ProjectCreationWizard {
 
 	public boolean performFinish() {
 		try {
+			setProjectNature(CONNECTOR_PROJECT_NATURE);
 			project = createNewProject();
 			pomfile = project.getFile("pom.xml").getLocation().toFile();
 			createPOM(pomfile, "pom");

--- a/plugins/org.wso2.developerstudio.eclipse.artifact.mediator/src/org/wso2/developerstudio/eclipse/artifact/mediator/ui/wizard/CustomMediatorCreationWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.mediator/src/org/wso2/developerstudio/eclipse/artifact/mediator/ui/wizard/CustomMediatorCreationWizard.java
@@ -94,6 +94,7 @@ public class CustomMediatorCreationWizard extends AbstractWSO2ProjectCreationWiz
 	    try {
 	    	
 			if(customMediatorModel.getSelectedOption().equals("new.mediator")){
+				setProjectNature(MEDIATOR_PROJECT_NATURE);
 				project = createNewProject();
 				IFolder  srcFolder= ProjectUtils.getWorkspaceFolder(project, "src", "main","java");
 		     	JavaUtils.addJavaSupportAndSourceFolder(project, srcFolder);	     	

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ESBProjectWizard.java
@@ -75,6 +75,7 @@ public class ESBProjectWizard extends AbstractWSO2ProjectCreationWizard {
 			if (esbProjectModel.getSelectedOption().equals("new.esb.synapseConfig")) {
 				esbArtiList =SynapseUtils.synapseConfigFolderContentProcessing(esbProjectModel.getSynapseConfigLocation().getPath());
 			}
+			setProjectNature(ESB_PROJECT_NATURE);
 			project = createNewProject();
 			pomfile = project.getFile("pom.xml").getLocation().toFile();
 			createPOM(pomfile,"pom");


### PR DESCRIPTION
## Purpose
Set project nature of the following projects:

1. Connector exporter project
2. Mediator Project
3. Esb Config project

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1046