### PR TITLE
CompositeApplication Creation wizard appears even if the Integration project has a Composite Application project

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/debugger/launch/ESBDebugLaunchDelegate.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/debugger/launch/ESBDebugLaunchDelegate.java
@@ -136,6 +136,12 @@ public class ESBDebugLaunchDelegate implements ILaunchConfigurationDelegate {
                 IResource selectedCARAppResource = selectedProject.getParent()
                         .findMember(currentProjectName + "CompositeApplication");
                 
+                //check selected project is created from new Integration Wizard
+                if (selectedCARAppResource == null) {
+                    selectedCARAppResource = selectedProject.getParent()
+                            .findMember(currentProjectName.split("ConfigProject")[0] + "CompositeApplication");
+                }
+                
                 boolean isCompositeSelectionPageNeeded = false;
                 if (selectedCARAppResource == null && currentProjectName != null
                         && !currentProjectName.contains("CompositeApplication")


### PR DESCRIPTION
## Purpose
> Related issue - https://github.com/wso2/devstudio-tooling-ei/issues/1043