### PR TITLE
[DataMapper] Enable array in array mapping

### DIFF
--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ANDOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ANDOperatorTransformer.java
@@ -40,10 +40,13 @@ public class ANDOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -54,15 +57,20 @@ public class ANDOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop,
+								unNamedVariables) + ")");
 			}
 
 			if (inputVariables.size() >= 2) {
 				for (int index = 1; index < inputVariables.size(); ++index) {
 					operationBuilder.append(CONSTANT_AND_OPERATOR + "("
 							+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(index),
-									variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-									outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+									variableTypeMap, tempParentForLoopBeanStack,
+									true, forLoopBeanList,
+									outputArrayVariableForLoop, 
+									outputArrayRootVariableForLoop, 
+									unNamedVariables)
 							+ ")");
 				}
 			}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbsoluteValueOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbsoluteValueOperatorTransformer.java
@@ -39,17 +39,21 @@ public class AbsoluteValueOperatorTransformer extends AbstractDMOperatorTransfor
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append("Math.abs(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables) + ")");
 			}
 			operationBuilder.append(";");
 		} else {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AbstractDMOperatorTransformer.java
@@ -37,7 +37,8 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 
 	protected String appendOutputVariable(DMOperation operation, List<DMVariable> outputVariables,
 			Map<String, List<SchemaDataType>> map, Stack<ForLoopBean> tempForLoopBeanParentStack,
-			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop)
+			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
 			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		int numOfOutputVariables = outputVariables.size();
@@ -47,14 +48,16 @@ public abstract class AbstractDMOperatorTransformer implements DMOperatorTransfo
 			if (operation.getOperatorType().equals(DataMapperOperatorType.INSTANTIATE)) {
 				prettyVariableName = ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						outputVariables.get(variableIndex), map, tempForLoopBeanParentStack, false, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables);
 				if (SchemaDataType.ARRAY.equals(operation.getProperty(TransformerConstants.VARIABLE_TYPE))) {
 					prettyVariableName = prettyVariableName.substring(0, prettyVariableName.lastIndexOf('['));
 				}
 			} else {
 				prettyVariableName = ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						outputVariables.get(variableIndex), map, tempForLoopBeanParentStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables);
 			}
 			operationBuilder.append(prettyVariableName);
 			if (variableIndex < (numOfOutputVariables - 1)) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AddOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/AddOperatorTransformer.java
@@ -40,10 +40,13 @@ public class AddOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -52,11 +55,16 @@ public class AddOperatorTransformer extends AbstractDMOperatorTransformer {
 			if (inputVariables.size() > 0) {
 				operationBuilder.append(CONSTANT_ADD_SIGN + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables));
 				for (int variableIndex = 1; variableIndex < inputVariables.size(); variableIndex++) {
 					operationBuilder.append(CONSTANT_ADD_SIGN + ScriptGenerationUtil
 							.getPrettyVariableNameInForOperation(inputVariables.get(variableIndex), variableTypeMap,
-									tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+									tempParentForLoopBeanStack, true, 
+									forLoopBeanList,
+									outputArrayVariableForLoop,
+									outputArrayRootVariableForLoop,
+									unNamedVariables));
 				}
 			}
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CeilOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CeilOperatorTransformer.java
@@ -39,17 +39,21 @@ public class CeilOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append("Math.ceil(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables) + ")");
 			}
 			operationBuilder.append(";");
 		} else {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CompareOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CompareOperatorTransformer.java
@@ -40,10 +40,13 @@ public class CompareOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		String operatorLiteral = ((ComparisonOperatorType) operator.getProperty(COMPARISON_OPERATOR_TYPE)).getLiteral();
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
@@ -56,11 +59,14 @@ public class CompareOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("( " + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop))
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables))
 						.append(" " + operatorLiteral + " "
 								+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(1),
 										variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-										outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+										outputArrayVariableForLoop,
+										outputArrayRootVariableForLoop,
+										unNamedVariables)
 								+ " )");
 			}
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ConcatOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ConcatOperatorTransformer.java
@@ -41,14 +41,17 @@ public class ConcatOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		String concatOperator = (String) operator.getProperty(DELIMITER_TAG);
 		if (concatOperator == null) {
 			concatOperator = "";
 		}
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 2) {
 				operationBuilder.append(inputVariables.get(0).getName() + JS_TO_STRING + ".concat('" + concatOperator
@@ -63,19 +66,25 @@ public class ConcatOperatorTransformer extends AbstractDMOperatorTransformer {
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
 			if (inputVariables.size() > 1) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables)
 						+ JS_TO_STRING);
 				for (int variableIndex = 1; variableIndex < inputVariables.size(); variableIndex++) {
 					operationBuilder.append(".concat('" + concatOperator + "',"
 							+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 									inputVariables.get(variableIndex), variableTypeMap, tempParentForLoopBeanStack,
-									true, null, null, outputArrayRootVariableForLoop)
+									true, null, null, 
+									outputArrayRootVariableForLoop, 
+									unNamedVariables)
 							+ ")");
 				}
 				operationBuilder.append(";");
 			} else if (inputVariables.size() == 1) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables)
 						+ JS_TO_STRING + ".concat('" + concatOperator + "');");
 			} else {
 				operationBuilder.append("'';");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ConstantOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ConstantOperatorTransformer.java
@@ -39,10 +39,13 @@ public class ConstantOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		String constantValue = (String) operator.getProperty(CONSTANT_VALUE_TAG);
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			operationBuilder.append("'" + constantValue + "';");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CustomFunctionOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/CustomFunctionOperatorTransformer.java
@@ -39,16 +39,20 @@ public class CustomFunctionOperatorTransformer extends AbstractDMOperatorTransfo
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		List<String> variableList = new ArrayList<>();
 		@SuppressWarnings("unchecked")
 		Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
 		for (DMVariable inputVariable : inputVariables) {
 			variableList.add(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariable, variableTypeMap,
-					tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+					tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, 
+					outputArrayRootVariableForLoop, unNamedVariables));
 		}
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			operationBuilder.append(operator.getProperty(TransformerConstants.CUSTOM_FUNCTION_NAME) + "(");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DMOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DMOperatorTransformer.java
@@ -49,5 +49,7 @@ public interface DMOperatorTransformer {
 	String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException;
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException;
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DirectOperatorTransformer.java
@@ -43,10 +43,13 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		SchemaDataType outputDataType = getOutputVariableType(outputVariables);
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
@@ -57,7 +60,9 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(this.appendTypeCorrectedInputVariable(operationBuilder, inputVariables, variableTypeMap, parentForLoopBeanStack,
-						forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop, outputDataType) + ";");
+						forLoopBeanList, outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, outputDataType,
+						unNamedVariables) + ";");
 			} else {
 				operationBuilder.append("'';");
 			}
@@ -70,12 +75,13 @@ public class DirectOperatorTransformer extends AbstractDMOperatorTransformer {
 	private String appendTypeCorrectedInputVariable(StringBuilder operationBuilder, List<DMVariable> inputVariables,
 			Map<String, List<SchemaDataType>> variableTypeMap, Stack<ForLoopBean> parentForLoopBeanStack,
 			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
-			Map<String, Integer> outputArrayRootVariableForLoop, SchemaDataType outputDataType) {
+			Map<String, Integer> outputArrayRootVariableForLoop, SchemaDataType outputDataType,
+			List<String> unNamedVariables) {
 
 		try {
 			String prettyVariable = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 					variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop,
-					outputArrayRootVariableForLoop);
+					outputArrayRootVariableForLoop, unNamedVariables);
 			SchemaDataType inputDataType = inputVariables.get(0).getSchemaVariableType();
 			String typeConvertedPrettyVariable = "";
 			if (!outputDataType.equals(inputDataType)) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DivideOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/DivideOperatorTransformer.java
@@ -40,10 +40,13 @@ public class DivideOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -51,13 +54,16 @@ public class DivideOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables));
 			}
 
 			if (inputVariables.size() == 2) {
 				operationBuilder.append(CONSTANT_DIVIDE_SIGN + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(1), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables));
 			}
 
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/EndsWithOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/EndsWithOperatorTransformer.java
@@ -41,10 +41,13 @@ public class EndsWithOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("EndsWith operator needs input string value to execute");
@@ -56,14 +59,18 @@ public class EndsWithOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+								outputArrayVariableForLoop, 
+								outputArrayRootVariableForLoop,
+								unNamedVariables) + ")");
 			}
 			if (inputMethod != null) {
 				if (inputVariables.size() == 2 && inputMethod.startsWith("{$")) {
 					operationBuilder.append(JS_TO_STRING + ".endsWith("
 							+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(1),
 									variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-									outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+									outputArrayVariableForLoop, 
+									outputArrayRootVariableForLoop,
+									unNamedVariables)
 							+ ")");
 				} else {
 					if (inputMethod.startsWith("{$")

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/FloorOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/FloorOperatorTransformer.java
@@ -39,17 +39,21 @@ public class FloorOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append("Math.floor(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables) + ")");
 			}
 			operationBuilder.append(";");
 		} else {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/GetOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/GetOperatorTransformer.java
@@ -38,17 +38,22 @@ public class GetOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		int arrayIndex = (int) operator.getProperty(TransformerConstants.GET_OPERATOR_INDEX);
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				throw new IllegalArgumentException("Get Operation input variables number can not be 0");
 			} else {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables)
 						+ "[" + arrayIndex + "]");
 			}
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/GlobalVariableOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/GlobalVariableOperatorTransformer.java
@@ -37,10 +37,13 @@ public class GlobalVariableOperatorTransformer extends AbstractDMOperatorTransfo
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		String variableName = (String) operator.getProperty(TransformerConstants.GLOBAL_VARIABLE_NAME);
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			operationBuilder.append(variableName + ";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/IfElseOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/IfElseOperatorTransformer.java
@@ -37,7 +37,9 @@ public class IfElseOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
@@ -47,28 +49,35 @@ public class IfElseOperatorTransformer extends AbstractDMOperatorTransformer {
 			}
 			if (inputVariables.size() >= 2) {
 				operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap,
-						parentForLoopBeanStack, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						parentForLoopBeanStack, forLoopBeanList, outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables));
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, 
+								unNamedVariables) + ")");
 				if (inputVariables.get(1) != null) {
 					operationBuilder.append("?(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(1), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 				} else {
 					operationBuilder.append("?(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							outputVariables.get(0), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 				}
 				if (inputVariables.size() > 2 && inputVariables.get(2) != null) {
 					operationBuilder.append(":(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(2), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 				} else {
 					operationBuilder.append(":(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							outputVariables.get(0), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 				}
 				operationBuilder.append(";");
 			} else {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/InstantiateOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/InstantiateOperatorTransformer.java
@@ -37,10 +37,13 @@ public class InstantiateOperatorTransformer extends AbstractDMOperatorTransforme
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (SchemaDataType.ARRAY.equals(operator.getProperty(TransformerConstants.VARIABLE_TYPE))) {
 				operationBuilder.append(" [];");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MatchOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MatchOperatorTransformer.java
@@ -41,10 +41,13 @@ public class MatchOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("Match operator needs input string value to execute");
@@ -56,13 +59,16 @@ public class MatchOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")" + JS_TO_STRING + ".match(");
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables) +
+								")" + JS_TO_STRING + ".match(");
 			}
 			if (customInput != null) {
 				if (inputVariables.size() == 2 && customInput.startsWith("{$")) {
 					operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(1), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables));
 				} else {
 					if (customInput.startsWith("{$") || StringUtils.isEmpty(customInput)) {
 						throw new IllegalArgumentException("Match operator needs pattern to execute."

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MaxOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MaxOperatorTransformer.java
@@ -37,10 +37,13 @@ public class MaxOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -48,11 +51,14 @@ public class MaxOperatorTransformer extends AbstractDMOperatorTransformer {
 			operationBuilder.append("Math.max(");
 			if (inputVariables.size() > 0) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables));
 				for (int variableIndex = 1; variableIndex < inputVariables.size(); variableIndex++) {
 					operationBuilder.append("," + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(variableIndex), variableTypeMap, tempParentForLoopBeanStack, true,
-							forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+							forLoopBeanList, outputArrayVariableForLoop,
+							outputArrayRootVariableForLoop, unNamedVariables));
 				}
 			} else {
 				operationBuilder.append("0");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MinOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MinOperatorTransformer.java
@@ -37,10 +37,13 @@ public class MinOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -48,11 +51,14 @@ public class MinOperatorTransformer extends AbstractDMOperatorTransformer {
 			operationBuilder.append("Math.min(");
 			if (inputVariables.size() > 0) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables));
 				for (int variableIndex = 1; variableIndex < inputVariables.size(); variableIndex++) {
 					operationBuilder.append("," + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(variableIndex), variableTypeMap, tempParentForLoopBeanStack, true,
-							forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+							forLoopBeanList, outputArrayVariableForLoop,
+							outputArrayRootVariableForLoop, unNamedVariables));
 				}
 			} else {
 				operationBuilder.append("0");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MultiplyOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/MultiplyOperatorTransformer.java
@@ -41,10 +41,13 @@ public class MultiplyOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -54,11 +57,17 @@ public class MultiplyOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append(CONSTANT_MULTIPLICATIVE);
 				operationBuilder.append(CONSTANT_MULTIPLY_SIGN + ScriptGenerationUtil
 						.getPrettyVariableNameInForOperation(inputVariables.get(0), variableTypeMap,
-								parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+								parentForLoopBeanStack, true, forLoopBeanList,
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables));
 				for (int variableIndex = 1; variableIndex < inputVariables.size(); variableIndex++) {
 					operationBuilder.append(CONSTANT_MULTIPLY_SIGN + ScriptGenerationUtil
 							.getPrettyVariableNameInForOperation(inputVariables.get(variableIndex), variableTypeMap,
-									tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+									tempParentForLoopBeanStack, true,
+									forLoopBeanList,
+									outputArrayVariableForLoop,
+									outputArrayRootVariableForLoop,
+									unNamedVariables));
 				}
 			}
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/NOTOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/NOTOperatorTransformer.java
@@ -40,10 +40,13 @@ public class NOTOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				/* Default value is true */
@@ -52,7 +55,9 @@ public class NOTOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append(CONSTANT_NOT_OPERATOR + "("
 						+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop,
+								unNamedVariables)
 						+ ")");
 			}
 

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/OROperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/OROperatorTransformer.java
@@ -40,10 +40,13 @@ public class OROperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -54,7 +57,9 @@ public class OROperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop,
+								unNamedVariables) + ")");
 			}
 
 			if (inputVariables.size() >= 2) {
@@ -62,7 +67,9 @@ public class OROperatorTransformer extends AbstractDMOperatorTransformer {
 					operationBuilder.append(CONSTANT_OR_OPERATOR + "("
 							+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(index),
 									variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-									outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+									outputArrayVariableForLoop,
+									outputArrayRootVariableForLoop, 
+									unNamedVariables)
 							+ ")");
 				}
 			}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/PropertiesOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/PropertiesOperatorTransformer.java
@@ -37,10 +37,13 @@ public class PropertiesOperatorTransformer extends AbstractDMOperatorTransformer
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+					throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			operationBuilder.append(PROPERTIES_PREFIX + "." + operator.getProperty(PROPERTY_SCOPE_TAG) + "['"
 					+ operator.getProperty(PROPERTY_NAME_TAG) + "']");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ReplaceOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ReplaceOperatorTransformer.java
@@ -41,11 +41,13 @@ public class ReplaceOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop)
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
 			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("Replace operator needs input string value to execute");
@@ -59,7 +61,8 @@ public class ReplaceOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append("("
 						+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables)
 						+ ")" + JS_TO_STRING + ".replace(");
 			}
 
@@ -67,14 +70,15 @@ public class ReplaceOperatorTransformer extends AbstractDMOperatorTransformer {
 				if (inputVariables.size() > 1 && inputVariables.get(1) != null) {
 					replaceFromValue = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(1),
 							variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables);
 				} else {
 					throw new IllegalArgumentException(
 							"Replace operator needs input element or configured value to Replace Target.");
 				}
 				replaceToValue = addReplaceToParamater(inputVariables, variableTypeMap, forLoopBeanList,
 						outputArrayVariableForLoop, replaceToCustomInput, tempParentForLoopBeanStack,
-						outputArrayRootVariableForLoop);
+						outputArrayRootVariableForLoop, unNamedVariables);
 
 			} else {
 				if (StringUtils.isNotEmpty(replaceFromCustomInput)) {
@@ -84,7 +88,7 @@ public class ReplaceOperatorTransformer extends AbstractDMOperatorTransformer {
 				}
 				replaceToValue = addReplaceToParamater(inputVariables, variableTypeMap, forLoopBeanList,
 						outputArrayVariableForLoop, replaceToCustomInput, tempParentForLoopBeanStack,
-						outputArrayRootVariableForLoop);
+						outputArrayRootVariableForLoop, unNamedVariables);
 			}
 			operationBuilder.append(replaceFromValue + "," + replaceToValue + ");");
 
@@ -97,14 +101,15 @@ public class ReplaceOperatorTransformer extends AbstractDMOperatorTransformer {
 	private String addReplaceToParamater(List<DMVariable> inputVariables,
 			Map<String, List<SchemaDataType>> variableTypeMap, List<ForLoopBean> forLoopBeanList,
 			Map<String, Integer> outputArrayVariableForLoop, String replaceToCustomInput,
-			Stack<ForLoopBean> tempParentForLoopBeanStack, Map<String, Integer> outputArrayRootVariableForLoop)
+			Stack<ForLoopBean> tempParentForLoopBeanStack, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
 			throws DataMapperException {
 		String replaceToValue;
 		if (replaceToCustomInput.startsWith("{$")) {
 			if (inputVariables.size() > 2 && inputVariables.get(2) != null) {
 				replaceToValue = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(2),
 						variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop,
-						outputArrayRootVariableForLoop);
+						outputArrayRootVariableForLoop, unNamedVariables);
 			} else {
 				throw new IllegalArgumentException(
 						"Replace operator needs input element" + " or configured value to Replace With.");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/RoundOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/RoundOperatorTransformer.java
@@ -39,17 +39,21 @@ public class RoundOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+					throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append("Math.round(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables) + ")");
 			}
 			operationBuilder.append(";");
 		} else {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SetPrecisionOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SetPrecisionOperatorTransformer.java
@@ -40,11 +40,14 @@ public class SetPrecisionOperatorTransformer extends AbstractDMOperatorTransform
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		String numOfDecimals = operator.getProperty(NUM_OF_DECIMALS_TAG).toString();
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("SetPrecision operator needs input interger value");
@@ -55,10 +58,12 @@ public class SetPrecisionOperatorTransformer extends AbstractDMOperatorTransform
 				if (numOfDecimals.startsWith("{$") && inputVariables.size() == 2) {
 					operationBuilder.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 					operationBuilder.append(".toFixed(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(1), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 				} else {
 					int decimalCount = 0;
 					try {
@@ -69,7 +74,8 @@ public class SetPrecisionOperatorTransformer extends AbstractDMOperatorTransform
 					}
 					operationBuilder.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 							inputVariables.get(0), variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables) + ")");
 					operationBuilder.append(".toFixed(" + decimalCount + ")");
 				}
 			}

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SplitOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SplitOperatorTransformer.java
@@ -40,14 +40,17 @@ public class SplitOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		String splitOperator = (String) operator.getProperty(DELIMITER_TAG);
 		if (splitOperator == null) {
 			splitOperator = ",";
 		}
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(inputVariables.get(0).getName() + ".split('" + splitOperator + "');");
@@ -57,7 +60,9 @@ public class SplitOperatorTransformer extends AbstractDMOperatorTransformer {
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables)
 						+ ".split('" + splitOperator + "');");
 			} else {
 				operationBuilder.append("'';");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StartsWithOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StartsWithOperatorTransformer.java
@@ -41,10 +41,13 @@ public class StartsWithOperatorTransformer extends AbstractDMOperatorTransformer
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("StartsWith operator needs input string value to execute");
@@ -56,14 +59,18 @@ public class StartsWithOperatorTransformer extends AbstractDMOperatorTransformer
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop,
+								unNamedVariables) + ")");
 			}
 			if (inputMethod != null) {
 				if (inputVariables.size() == 2 && inputMethod.startsWith("{$")) {
 					operationBuilder.append(JS_TO_STRING + ".startsWith("
 							+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(1),
 									variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-									outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+									outputArrayVariableForLoop,
+									outputArrayRootVariableForLoop,
+									unNamedVariables)
 							+ ")");
 				} else {
 					if (inputMethod.startsWith("{$")

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringLengthOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringLengthOperatorTransformer.java
@@ -41,10 +41,13 @@ public class StringLengthOperatorTransformer extends AbstractDMOperatorTransform
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop, 
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() == 0) {
 				/* Default value is 0 */
@@ -54,7 +57,9 @@ public class StringLengthOperatorTransformer extends AbstractDMOperatorTransform
 						.append("("
 								+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 										variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-										outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+										outputArrayVariableForLoop,
+										outputArrayRootVariableForLoop,
+										unNamedVariables)
 								+ ")" + JS_TO_STRING + CONSTANT_STRING_LENGTH);
 			}
 

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringToBlooeanOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringToBlooeanOperatorTransformer.java
@@ -37,10 +37,13 @@ public class StringToBlooeanOperatorTransformer extends AbstractDMOperatorTransf
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+					throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -50,7 +53,9 @@ public class StringToBlooeanOperatorTransformer extends AbstractDMOperatorTransf
 				operationBuilder
 						.append(" " + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ".toString().toLowerCase() === 'true'");
+								outputArrayVariableForLoop, 
+								outputArrayRootVariableForLoop, unNamedVariables) +
+								".toString().toLowerCase() === 'true'");
 			}
 
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringToNumberOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/StringToNumberOperatorTransformer.java
@@ -37,10 +37,13 @@ public class StringToNumberOperatorTransformer extends AbstractDMOperatorTransfo
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -49,7 +52,8 @@ public class StringToNumberOperatorTransformer extends AbstractDMOperatorTransfo
 			} else {
 				operationBuilder.append("Number(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(
 						inputVariables.get(0), variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-						outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")");
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables) + ")");
 			}
 
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SubstringOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SubstringOperatorTransformer.java
@@ -40,11 +40,13 @@ public class SubstringOperatorTransformer extends AbstractDMOperatorTransformer 
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop)
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
 			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.get(0) == null) {
 				throw new IllegalArgumentException("Substring operator needs input string value to execute");
@@ -59,7 +61,8 @@ public class SubstringOperatorTransformer extends AbstractDMOperatorTransformer 
 				operationBuilder.append("("
 						+ ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables)
 						+ ")" + JS_TO_STRING + ".substring(");
 			}
 
@@ -68,18 +71,21 @@ public class SubstringOperatorTransformer extends AbstractDMOperatorTransformer 
 				if (inputVariables.size() > 1 && inputVariables.get(1) != null) {
 					startValue = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(1),
 							variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-							outputArrayVariableForLoop, outputArrayRootVariableForLoop);
+							outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+							unNamedVariables);
 				} else {
 					throw new IllegalArgumentException(
 							"Substring operator needs input element" + " or configured value to Start Index.");
 				}
 				lengthValue = getLengthValue(inputVariables, variableTypeMap, forLoopBeanList,
-						outputArrayVariableForLoop, length, tempParentForLoopBeanStack, outputArrayRootVariableForLoop);
+						outputArrayVariableForLoop, length, tempParentForLoopBeanStack,
+						outputArrayRootVariableForLoop, unNamedVariables);
 
 			} else {
 				startValue = startIndex;
 				lengthValue = getLengthValue(inputVariables, variableTypeMap, forLoopBeanList,
-						outputArrayVariableForLoop, length, tempParentForLoopBeanStack, outputArrayRootVariableForLoop);
+						outputArrayVariableForLoop, length, tempParentForLoopBeanStack,
+						outputArrayRootVariableForLoop, unNamedVariables);
 			}
 
 			operationBuilder.append(startValue + "," + startValue + "+" + lengthValue + ")");
@@ -93,14 +99,15 @@ public class SubstringOperatorTransformer extends AbstractDMOperatorTransformer 
 
 	private String getLengthValue(List<DMVariable> inputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop, String length,
-			Stack<ForLoopBean> tempParentForLoopBeanStack, Map<String, Integer> outputArrayRootVariableForLoop)
+			Stack<ForLoopBean> tempParentForLoopBeanStack,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
 			throws DataMapperException {
 		String lengthValue;
 		if (length.startsWith("{$")) {
 			if (inputVariables.size() > 2 && inputVariables.get(2) != null) {
 				lengthValue = ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(2),
 						variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop,
-						outputArrayRootVariableForLoop);
+						outputArrayRootVariableForLoop, unNamedVariables);
 			} else {
 				throw new IllegalArgumentException(
 						"Substring operator needs input element" + " or configured value to Length.");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SubtractOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/SubtractOperatorTransformer.java
@@ -40,10 +40,13 @@ public class SubtractOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop,
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -51,13 +54,17 @@ public class SubtractOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append(CONSTANT_ADDITIVE);
 			} else {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables));
 			}
 
 			if (inputVariables.size() == 2) {
 				operationBuilder.append(CONSTANT_SUBTRACT_SIGN + ScriptGenerationUtil
 						.getPrettyVariableNameInForOperation(inputVariables.get(1), variableTypeMap,
-								tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+								tempParentForLoopBeanStack, true, forLoopBeanList,
+								outputArrayVariableForLoop,
+								outputArrayRootVariableForLoop, unNamedVariables));
 			}
 
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToLowerCaseOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToLowerCaseOperatorTransformer.java
@@ -40,10 +40,13 @@ public class ToLowerCaseOperatorTransformer extends AbstractDMOperatorTransforme
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(inputVariables.get(0).getName() + JS_TO_STRING + ".toLowerCase();");
@@ -53,7 +56,9 @@ public class ToLowerCaseOperatorTransformer extends AbstractDMOperatorTransforme
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables)
 						+ JS_TO_STRING + ".toLowerCase();");
 			} else {
 				operationBuilder.append("'';");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToStringOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToStringOperatorTransformer.java
@@ -39,10 +39,13 @@ public class ToStringOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -52,7 +55,9 @@ public class ToStringOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder
 						.append("(" + ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
 								variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
-								outputArrayVariableForLoop, outputArrayRootVariableForLoop) + ")" + JS_TO_STRING);
+								outputArrayVariableForLoop, 
+								outputArrayRootVariableForLoop, unNamedVariables) +
+								")" + JS_TO_STRING);
 			}
 			operationBuilder.append(";");
 

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToUpperCaseOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/ToUpperCaseOperatorTransformer.java
@@ -40,10 +40,13 @@ public class ToUpperCaseOperatorTransformer extends AbstractDMOperatorTransforme
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (SameLevelRecordMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(inputVariables.get(0).getName() + JS_TO_STRING + ".toUpperCase();");
@@ -53,7 +56,9 @@ public class ToUpperCaseOperatorTransformer extends AbstractDMOperatorTransforme
 		} else if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			if (inputVariables.size() >= 1) {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, parentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop,
+						outputArrayRootVariableForLoop, unNamedVariables)
 						+ JS_TO_STRING + ".toUpperCase();");
 			} else {
 				operationBuilder.append("'';");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/TrimOperatorTransformer.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/configuration/operator/transformers/TrimOperatorTransformer.java
@@ -39,10 +39,13 @@ public class TrimOperatorTransformer extends AbstractDMOperatorTransformer {
 	public String generateScriptForOperation(Class<?> generatorClass, List<DMVariable> inputVariables,
 			List<DMVariable> outputVariables, Map<String, List<SchemaDataType>> variableTypeMap,
 			Stack<ForLoopBean> parentForLoopBeanStack, DMOperation operator, List<ForLoopBean> forLoopBeanList,
-			Map<String, Integer> outputArrayVariableForLoop, Map<String, Integer> outputArrayRootVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputArrayVariableForLoop, 
+			Map<String, Integer> outputArrayRootVariableForLoop, List<String> unNamedVariables)
+			throws DataMapperException {
 		StringBuilder operationBuilder = new StringBuilder();
 		operationBuilder.append(appendOutputVariable(operator, outputVariables, variableTypeMap, parentForLoopBeanStack,
-				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop));
+				forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+				unNamedVariables));
 		if (DifferentLevelArrayMappingConfigGenerator.class.equals(generatorClass)) {
 			@SuppressWarnings("unchecked")
 			Stack<ForLoopBean> tempParentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStack.clone();
@@ -50,7 +53,9 @@ public class TrimOperatorTransformer extends AbstractDMOperatorTransformer {
 				operationBuilder.append("");
 			} else {
 				operationBuilder.append(ScriptGenerationUtil.getPrettyVariableNameInForOperation(inputVariables.get(0),
-						variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList, outputArrayVariableForLoop, outputArrayRootVariableForLoop)
+						variableTypeMap, tempParentForLoopBeanStack, true, forLoopBeanList,
+						outputArrayVariableForLoop, outputArrayRootVariableForLoop,
+						unNamedVariables)
 						+ JS_TO_STRING + ".trim()");
 			}
 			operationBuilder.append(";");

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/model/DataMapperDiagramModel.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/model/DataMapperDiagramModel.java
@@ -65,6 +65,7 @@ public class DataMapperDiagramModel {
 	private static final String NAMESPACE_SEPERATOR = ":";
 	private static final String JSON_SCHEMA_NULLABLE = "nullable";
 	private static final String DOT_REPRESENTATION = "_DOT_";
+	private static final String UNAMED = "unnamed";
 	private List<DMVariable> variablesArray = new ArrayList<>();
 	private List<Integer> inputVariablesArray = new ArrayList<>();
 	private List<Integer> outputVariablesArray = new ArrayList<>();
@@ -77,6 +78,7 @@ public class DataMapperDiagramModel {
 	private List<ArrayList<Integer>> outputAdjList = new ArrayList<>();
 	private List<Integer> executionSeq = new ArrayList<>();
 	private Map<String, List<SchemaDataType>> variableTypeMap = new HashMap<>();
+	private List<String> unNamedVariables = new ArrayList<>();
 	private String inputRootName;
 	private String outputRootName;
 
@@ -134,6 +136,9 @@ public class DataMapperDiagramModel {
 				outputVariablesArray.add(index);
 				currentTreeNode.setIndex(index);
 				addVariableTypeToMap(addedVariable.getName(), variableType);
+				if(isUnNamed(currentTreeNode)) {
+					getUnNamedVariables().add(addedVariable.getName());
+				}
 				if (isTreeNodeElementNullable(currentNode)) {
 					addVariableTypeToMap(addedVariable.getName(), SchemaDataType.NULL);
 				}
@@ -158,6 +163,21 @@ public class DataMapperDiagramModel {
 		}
 		addOtherRootElemetsToNodeArray(tempNodeArray, input);
 		populateAdjacencyLists(tempNodeArray);
+	}
+	
+	/**
+	 * Given a treenode, check if unnamed property is true.
+	 * 
+	 * @param currentTreeNode treenode to check
+	 * @return unnamed value
+	 */
+	private boolean isUnNamed(TreeNodeImpl currentTreeNode) {
+		for (PropertyKeyValuePair property: currentTreeNode.getProperties()) {
+			if (UNAMED.equals(property.getKey())) {
+				return Boolean.parseBoolean(property.getValue());
+			}
+		}
+		return false;
 	}
 
 	private boolean isTreeNodeElementNullable(EObject currentTreeNode) {
@@ -950,6 +970,9 @@ public class DataMapperDiagramModel {
 				outputVariablesArray.add(variableIndex);
 				currentTreeNode.setIndex(variableIndex);
 				addVariableTypeToMap(variableName, variableType);
+				if (isUnNamed(currentTreeNode)) {
+					getUnNamedVariables().add(variableName);
+				}
 				if (currentTreeNode.getLevel() == parentVariableStack.size()) {
 					parentVariableStack.pop();
 					parentVariableStack.push(currentTreeNode);
@@ -1174,6 +1197,10 @@ public class DataMapperDiagramModel {
 	
 	private String replaceSpecialCharactersInAttribute(String attributeName) {
 	    return attributeName.replace(".", DOT_REPRESENTATION);
+	}
+
+	public List<String> getUnNamedVariables() {
+		return unNamedVariables;
 	}
 
 }

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/custom/util/ScriptGenerationUtil.java
@@ -39,12 +39,15 @@ public class ScriptGenerationUtil {
 	private static final String DOT_REPRESENTATION = "_DOT_";
 	private static final int VARIABLE_TYPE_INDEX = 0;
 	private static final String HYPHEN_PREFIX = "_EnC0DeCHaRHyPh3n_";
+	private static final String SQ_BRACKET_OPEN = "[";
+	private static final String SQ_BRACKET_CLOSE = "]";
 	public static final String VALID_VARIABLE_NAME_REGEX = "^[a-zA-Z][a-zA-Z_$0-9]*$";
 
 	public static String getPrettyVariableNameInForOperation(DMVariable variable, Map<String, List<SchemaDataType>> map,
 			Stack<ForLoopBean> parentForLoopBeanStackTemp, boolean isOperationVariable,
 			List<ForLoopBean> forLoopBeanList, Map<String, Integer> outputArrayVariableForLoop,
-			Map<String, Integer> outputRootArrayVariableForLoop) throws DataMapperException {
+			Map<String, Integer> outputRootArrayVariableForLoop, List<String> unNamedVariables) 
+			throws DataMapperException {
 		@SuppressWarnings("unchecked")
 		Stack<ForLoopBean> parentForLoopBeanStack = (Stack<ForLoopBean>) parentForLoopBeanStackTemp.clone();
 		// put index values for array type variables
@@ -112,7 +115,14 @@ public class ScriptGenerationUtil {
 						if (iterateName.isEmpty()) {
 							iterateName = "0";
 						}
-						prettyVariableName += getValidNextName(nextName) + "[" + iterateName + "]";
+						// Discard unnamed variables.
+						if (unNamedVariables.contains(variableName)) {
+							prettyVariableName += SQ_BRACKET_OPEN + iterateName +
+									SQ_BRACKET_CLOSE;
+						} else {
+							prettyVariableName += getValidNextName(nextName) +
+									SQ_BRACKET_OPEN + iterateName + SQ_BRACKET_CLOSE;
+						}
 					} else if (nextName.startsWith("@") && isPerviousVariableTypePrimitive) {
 						prettyVariableName += "ATTR" + getValidNextName(nextName.replaceFirst("@", "attr_"));
 					} else if (nextName.startsWith("@")) {
@@ -184,7 +194,14 @@ public class ScriptGenerationUtil {
 						if (iterateName.isEmpty()) {
 							iterateName = "0";
 						}
-						prettyVariableName += getValidNextName(nextName) + "[" + iterateName + "]";
+						// Discard unnamed variables.
+						if (unNamedVariables.contains(variableName)) {
+							prettyVariableName += SQ_BRACKET_OPEN + iterateName + 
+									SQ_BRACKET_CLOSE;
+						} else {
+							prettyVariableName += getValidNextName(nextName) + 
+									SQ_BRACKET_OPEN + iterateName + SQ_BRACKET_CLOSE;
+						}
 					} else if (nextName.startsWith("@") && isPerviousVariableTypePrimitive) {
 						prettyVariableName += "ATTR" + getValidNextName(nextName.replaceFirst("@", "attr_"));
 					} else if (nextName.startsWith("@")) {
@@ -221,7 +238,14 @@ public class ScriptGenerationUtil {
 						} else {
 							iterateName = parentVariableBottomUpStack.pop().getIterativeName();
 						}
-						prettyVariableName += getValidNextName(nextName) + "[" + iterateName + "]";
+						// Discard unnamed variables.
+						if (unNamedVariables.contains(variableName)) {
+							prettyVariableName += SQ_BRACKET_OPEN + iterateName +
+									SQ_BRACKET_CLOSE;
+						} else {
+							prettyVariableName += getValidNextName(nextName) +
+									SQ_BRACKET_OPEN + iterateName + SQ_BRACKET_CLOSE;
+						}
 					} else if (nextName.startsWith("@") && isPerviousVariableTypePrimitive) {
 						prettyVariableName += "ATTR" + getValidNextName(nextName.replaceFirst("@", "attr_"));
 					} else if (nextName.startsWith("@")) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaBuilder.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper.diagram/src/org/wso2/developerstudio/datamapper/diagram/schemagen/util/SchemaBuilder.java
@@ -57,6 +57,7 @@ public class SchemaBuilder {
 	private static final String XSI_NAMESPACE_URI = "http://www.w3.org/2001/XMLSchema-instance";
 	private static final String XML = "xml";
 	private static final String JSON = "json";
+	private static final String ZERO = "0";
 	
 
 	protected JsonSchema root;
@@ -441,6 +442,12 @@ public class SchemaBuilder {
 					newJObj.add(name, value);
 				}
 			}
+		} else if (propertyValueType == TypeEnum.ARRAY) {
+			for (JsonElement subChildElement : childElement.getAsJsonArray()) {
+				JsonSchema schemaArray = addArrayToParentItemsArray(parent, ZERO);
+				createSchemaForArray(subChildElement, schemaArray, ZERO, jsonObject);
+				break;
+			}
 		} else {
 			addPrimitiveToParentItemsArray(parent, "0", propertyValueType);
 		}
@@ -534,6 +541,21 @@ public class SchemaBuilder {
 		JsonSchema schema = new JsonSchema();
 		schema.setId(parent.getId() + "/" + id);
 		schema.setType(OBJECT);
+		parent.addArrayItem(id, schema);
+		return schema;
+	}
+	
+	/**
+	 * Add an array type object into parents items array.
+	 * 
+	 * @param parent parent schema
+	 * @param id identifier of the new object
+	 * @return new schema
+	 */
+	protected JsonSchema addArrayToParentItemsArray(JsonSchema parent, String id) {
+		JsonSchema schema = new JsonSchema();
+		schema.setId(parent.getId() + "/" + id);
+		schema.setType(ARRAY);
 		parent.addArrayItem(id, schema);
 		return schema;
 	}


### PR DESCRIPTION
## Purpose
Enables array in array mappings. Includes following changes:
1. SchemaBuilder -> Change to load schemas with nested arrays
2. SchemaTransformer -> Change to create the data mapper Treenodes for arrays in arrays
3. DataMapperDiagramModel -> Change to hold an array of variables (transformed Treenodes) that should not have names
4. ScriptGenerationUtil -> Change to discard unnamed variables when generating variable names.
5. Other changes are to allow passing the unNamedVariables array to relevant methods.

Related Issue: https://github.com/wso2/devstudio-tooling-ei/issues/1093