### PR TITLE
Add program argument(IntegrationStudio.ini) to use legacy properties view

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/components/CloudConnectorOperationPropertiesEditionComponent.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/components/CloudConnectorOperationPropertiesEditionComponent.java
@@ -59,6 +59,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
 import org.wso2.developerstudio.eclipse.gmf.esb.parts.CloudConnectorOperationPropertiesEditionPart;
 import org.wso2.developerstudio.eclipse.gmf.esb.parts.EsbViewsRepository;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.ConnectorSchemaHolder;
+import org.wso2.developerstudio.eclipse.gmf.esb.presentation.EEFPropertyViewUtil;
 
 
 // End of user code
@@ -242,7 +243,7 @@ public class CloudConnectorOperationPropertiesEditionComponent extends SinglePar
 
 		if (EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters == event.getAffectedEditor()) {
 		      String schemaName = cloudConnectorOperation.getConnectorName().split("connector")[0] + "-" + cloudConnectorOperation.getOperationName();
-		      if(ConnectorSchemaHolder.getInstance().hasConnectorOperationSchema(schemaName)) {
+		      if(ConnectorSchemaHolder.getInstance().hasConnectorOperationSchema(schemaName) && (!EEFPropertyViewUtil.isLegacyPropertiesViewSet())) {
 		          EList connectorParams = cloudConnectorOperation.getConnectorParameters();
 	              int index = connectorParams.indexOf(event.getOldValue());
 	              CallTemplateParameter ctpi = (CallTemplateParameter)connectorParams.get(index);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
@@ -159,7 +159,8 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
 	 */
 	public Composite createFigure(final Composite parent, final FormToolkit widgetFactory) {
 	    String schemaName = EEFPropertyViewUtil.generateSchemaName(propertiesEditionComponent);
-        if(ConnectorSchemaHolder.getInstance().hasConnectorOperationSchema(schemaName)) {
+        if(ConnectorSchemaHolder.getInstance().hasConnectorOperationSchema(schemaName)
+                && (!EEFPropertyViewUtil.isLegacyPropertiesViewSet())) {
 	        hasConnectorSchema = true;
 	    } else {
 	        hasConnectorSchema = false;

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyConstants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyConstants.java
@@ -29,4 +29,5 @@ public class EEFPropertyConstants {
     public static String REQUIRED_FIELD_INDICATOR = "*";
     public static String EXPRESSION_FIELD_SUFFIX = "exp";
     public static String ECORE_CONNECTOR_NAME_SUFFIX = "connector";
+    public static String ENABLE_LEGACY_PROPERTY_VIEW_PROGRAM_ARG = "org.wso2.developerstudio.properties.legacy";
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
@@ -533,4 +533,19 @@ public class EEFPropertyViewUtil {
         MavenUtils.saveMavenProject(mavenProject, mavenProjectPomLocation);
         return mavenProject;
     }
+
+    /**
+     * Get whether the -Dorg.wso2.developerstudio.properties.legacy is set as a program argument in
+     * IntegrationStudio.ini file
+     * @return true if program argument is available
+     */
+    public static boolean isLegacyPropertiesViewSet() {
+        String [] args = Platform.getApplicationArgs();
+        for(String param:args) {
+            if(param.substring(2).equals(EEFPropertyConstants.ENABLE_LEGACY_PROPERTY_VIEW_PROGRAM_ARG)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Purpose
Add option to use legacy properties view(Table based). With this if we use below argument in IntegrationStudio.ini it will use legacy properties view even though connector json descriptor is available.

`-Dorg.wso2.developerstudio.properties.legacy`

Fixes https://github.com/wso2/devstudio-tooling-ei/issues/1128