### PR TITLE
Fix: Not opening MI dashboard in windows

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/DeployedEndpointsPages/index.html
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/DeployedEndpointsPages/index.html
@@ -91,7 +91,7 @@
 					<div class="alert alert-danger" role="alert" id="failed-alert" hidden="true">
 						Open failed.
 					</div>
-					<a href="#" id="open-monitoring-dashboard">More Information</a>
+					<a href="#" id="open-monitoring-dashboard">Open Monitoring Dashboard.</a>
 				</div>
 			</div>
 		</div>

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/DeployedEndpointsPages/js/store.js
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/DeployedEndpointsPages/js/store.js
@@ -85,18 +85,20 @@ function openDashboard() {
 	$.ajax({
 		url: "http://127.0.0.1:" + port + "/project/endpoints/services",
 		type: "GET",
-		dataType: "text",
-		cache: true,
+		cache: false,
 		success: function(data) {
 			$(LOADING_ALERT).modal(HIDE);
 		},
 		error: function(jqXHR, textStatus, errorThrown) {
 			$(LOADING_ALERT).modal(HIDE);
-			$(FAILED_ALERT).prop(HIDDEN, false);
-			$(FAILED_ALERT)[0].innerText = getErrorMessage(jqXHR, errorThrown);
-			setTimeout(function() {
-				$(FAILED_ALERT).prop(HIDDEN, true);
-			}, 10000);
+			errorMessage = getErrorMessage(jqXHR, errorThrown);
+			if (errorMessage != null && errorMessage != "") {
+				$(FAILED_ALERT).prop(HIDDEN, false);
+				$(FAILED_ALERT)[0].innerText = errorMessage;
+				setTimeout(function() {
+					$(FAILED_ALERT).prop(HIDDEN, true);
+				}, 10000);
+			}
 		},
 	});
 }

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/servlets/DeployedServicesServlet.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/servlets/DeployedServicesServlet.java
@@ -36,8 +36,6 @@ import org.wso2.developerstudio.eclipse.logging.core.Logger;
 
 public class DeployedServicesServlet extends HttpServlet {
 
-    private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
-
     /**
      * Handles get requests.
      * 
@@ -50,9 +48,9 @@ public class DeployedServicesServlet extends HttpServlet {
         try {
             String url = MonitoringDashboard.getInstance().getUrl();
             PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser().openURL(new URL(url));
+            DeployedServicesServletUtil.setMessage("message", "success", response);
             response.setStatus(HttpServletResponse.SC_OK);
         } catch (PartInitException | IOException e) {
-            log.error("Could not load the monitoring dashboard.", e);
             DeployedServicesServletUtil.setErrorMessage(e.getMessage(), response);
         }
     }

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/servlets/utils/DeployedServicesServletUtil.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/servlets/utils/DeployedServicesServletUtil.java
@@ -19,15 +19,22 @@
 package org.wso2.developerstudio.eclipse.esb.project.servlets.utils;
 
 import java.io.IOException;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.wso2.developerstudio.eclipse.esb.project.Activator;
+import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
+import org.wso2.developerstudio.eclipse.logging.core.Logger;
+
 import com.google.gson.Gson;
 
 public class DeployedServicesServletUtil {
 
+    private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
+    
     /**
      * Write given error message to the response.
      * 
@@ -36,10 +43,25 @@ public class DeployedServicesServletUtil {
      * @throws IOException 
      */
     public static void setErrorMessage(String errorMessage, HttpServletResponse response) throws IOException {
-        Map<String, Object> data = new HashMap<>();
-        data.put("error", errorMessage);
-        response.setContentType("application/json");
         response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
-        response.getWriter().println(new Gson().toJson(data));
+        setMessage("error", errorMessage, response);
+        log.error(errorMessage);
+    }
+    
+    
+    /**
+     * Write a given message to the response.
+     * 
+     * @param messageKey key of the message
+     * @param messageValue message to set
+     * @param response servlet response
+     * @throws IOException
+     */
+    public static void setMessage(String messageKey, String messageValue, HttpServletResponse response)
+            throws IOException {
+        Map<String, Object> data = new HashMap<>();
+        data.put(messageKey, messageValue);
+        response.setContentType("application/json");
+        response.getWriter().println(new Gson().toJson(data, Map.class));
     }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/view/DeployedServicesView.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/view/DeployedServicesView.java
@@ -99,7 +99,7 @@ public class DeployedServicesView extends ViewPart {
             throws URISyntaxException, IOException {
         IEclipsePreferences rootNode = Platform.getPreferencesService().getRootNode();
         String port = rootNode.get("portDetails", String.valueOf(FunctionServerConstants.EMBEDDED_SERVER_PORT));
-        return "http://localhost:" + port + "/project/endpoints?" + API_DETAILS_GET_PARAM + "=" + apiList + "&"
+        return "http://127.0.0.1:" + port + "/project/endpoints?" + API_DETAILS_GET_PARAM + "=" + apiList + "&"
                 + PROXY_DETAILS_GET_PARAM + "=" + proxyList + "&" + DATASERVICE_DETAILS_GET_PARAM + "="
                 + dataServiceList + "&port=" + port;
     }


### PR DESCRIPTION
## Purpose
This was fixed by changing `cache` to `false`.

Also includes,
1. Change text in the HTML from `more information` to `Open Monitoring Dashboard`.
2. In the servlet, add a message into the response when successfully opened the dashboard.