### PR TITLE
Add capability to change Palatte entry as Modules

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/CloudConnectorDirectoryTraverser.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/CloudConnectorDirectoryTraverser.java
@@ -411,6 +411,10 @@ public class CloudConnectorDirectoryTraverser {
             return "";
         }
     }
+    
+    public String getConnectorType() {
+        return connector.getConnectorType();
+    }
 
     public String getCloudConnectorName() {
         try {

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/Connector.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/custom/cloudconnector/Connector.java
@@ -29,6 +29,7 @@ public class Connector extends AbstractXMLDoc {
     private List<Dependency> componentDependencies = new ArrayList<Dependency>();
     private String connectorName = null;
     private String authenticationInfo = null;
+    private String connectorType = null;
 
     public String getAuthenticationInfo() {
         return authenticationInfo;
@@ -53,11 +54,24 @@ public class Connector extends AbstractXMLDoc {
     public void setComponentDependencies(List<Dependency> componentDependencies) {
         this.componentDependencies = componentDependencies;
     }
+    
+    public void setConnectorType(String connectorType) {
+        this.connectorType = connectorType;
+    }
+    
+    public String getConnectorType() {
+        return this.connectorType;
+    }
 
     @Override
     protected void deserialize(OMElement documentElement) throws Exception {
         List<OMElement> component = getChildElements(documentElement, "component");
         setConnectorName(component.get(0).getAttributeValue(new QName("name")));
+        List<OMElement> type = getChildElements(documentElement, "type");
+        if (!type.isEmpty()) {
+            setConnectorType(type.get(0).getText());
+        }
+        
         for (OMElement omElement : component) {
             List<OMElement> artifactElements = getChildElements(omElement, "dependency");
             for (OMElement omElement2 : artifactElements) {

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbPaletteFactory.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/part/EsbPaletteFactory.java
@@ -1556,6 +1556,7 @@ public class EsbPaletteFactory {
         Set<String> cloudConnectorOperations = Collections.emptySet();
         String connectorPath = null;
         String cloudConnectorName = connectorDirectoryName.split("-")[0];
+        String connectorType = "Connector";
 
         /*
          * IEditorPart editorpart = PlatformUI.getWorkbench().getActiveWorkbenchWindow()
@@ -1568,9 +1569,12 @@ public class EsbPaletteFactory {
         // + "cloudConnectors" + File.separator + connectorDirectoryName;
         connectorPath = activeProject.getWorkspace().getRoot().getLocation().toOSString() + File.separator
                 + CloudConnectorDirectoryTraverser.connectorPathFromWorkspace + File.separator + connectorDirectoryName;
-        cloudConnectorOperations = CloudConnectorDirectoryTraverser.getInstance(connectorPath).getOperationsMap()
-                .keySet();
-
+        CloudConnectorDirectoryTraverser cloudConnectorTraverser = CloudConnectorDirectoryTraverser
+                .getInstance(connectorPath);
+        cloudConnectorOperations = cloudConnectorTraverser.getOperationsMap().keySet();
+        if (cloudConnectorTraverser.getConnectorType() != null) {
+            connectorType = cloudConnectorTraverser.getConnectorType();
+        }
         boolean definedEndpointsAdded = false;
         int indexOfDefinedEndpoints = 0;
 
@@ -1588,7 +1592,7 @@ public class EsbPaletteFactory {
 
         if (!definedEndpointsAdded) {
             ((DiagramEditDomain) ((EsbDiagramEditor) editor).getDiagramEditDomain()).getPaletteViewer().getPaletteRoot()
-                    .add(createCloudConnectorGroup(WordUtils.capitalize(cloudConnectorName) + " Connector",
+                    .add(createCloudConnectorGroup(WordUtils.capitalize(cloudConnectorName) + " " + WordUtils.capitalize(connectorType),
                             "CloudConnector-" + cloudConnectorName));
             indexOfDefinedEndpoints = list.size() - 1;
         } /*


### PR DESCRIPTION
## Purpose
> Fix: https://github.com/wso2/devstudio-tooling-ei/issues/1167

Use  **type** entry as 'module' or 'connector' as follows,

```xml
<?xml version="1.0" encoding="UTF-8"?>
<connector>
    <component name="fileconnector" package="org.wso2.carbon.connector">
        <dependency component="file"/>
        <description>wso2 file connector</description>
    </component>
    <icon>icon/icon-small.gif</icon>
    <type>module</type>
</connector>
```