### PR TITLE
Rename project wizard extensions

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.connector/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.connector/plugin.xml
@@ -2,13 +2,13 @@
 <?eclipse version="3.4"?>
 <plugin>
  <extension point="org.eclipse.ui.newWizards">
-		<wizard name="Connector Exporter Project" 
+		<wizard name="Connector Exporter" 
 			category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.extensions/org.wso2.developerstudio.eclipse.extensions.project.types"
 			class="org.wso2.developerstudio.eclipse.artifact.connector.ui.wizard.ConnectorCreationWizard"
 			wizardManifest="project_wizard.xml"
 			id="org.wso2.developerstudio.eclipse.artifact.newconnectorartifact"
 			project="true" icon="icons/new-mediator-16x16.png">
-			<description>Connector Project</description>
+			<description>Connector Exporter</description>
 		</wizard>
 	</extension>
 	<extension point="org.wso2.developerstudio.eclipse.capp.artifacts.provider">

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/plugin.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/plugin.xml
@@ -17,14 +17,14 @@
 	
 	<extension
          point="org.eclipse.ui.newWizards">
-         <wizard name="ESB Config Project"
+         <wizard name="ESB Configs"
 			category="org.wso2.developerstudio.eclipse.capp.project/org.wso2.developerstudio.eclipse.message.mediation/org.wso2.developerstudio.eclipse.message.mediation.project.types"
 			class="org.wso2.developerstudio.eclipse.esb.project.ui.wizard.ESBProjectWizard"
 			id="org.wso2.developerstudio.eclipse.artifact.newesbproject"
 			wizardManifest="project_wizard.xml"
 			icon="icons/esb-project-12.png"
 			project="true">
-			<description>ESB Config Project</description>
+			<description>ESB Configs</description>
 		</wizard>
    </extension>
   
@@ -57,7 +57,7 @@
             <command
                   commandId="developerstudio.commands.new.esbConfigProject"
                   icon="icons/esb-project-12.png"
-                  label="ESB Config Project">
+                  label="ESB Configs">
                   <!-- Adding visibleWhen to visible the item only when clicking on the project explorer-->
                   <visibleWhen
                      checkEnabled="false">


### PR DESCRIPTION
Rename project wizard extensions for connector and esb configs module.
Fix https://github.com/wso2/devstudio-tooling-ei/issues/1212