### PR TITLE
Connector param table improvements

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
@@ -69,6 +69,8 @@ import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.FormAttachment;
+import org.eclipse.swt.layout.FormData;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 
@@ -79,12 +81,14 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.forms.widgets.Form;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.eclipse.ui.forms.widgets.ScrolledForm;
 import org.eclipse.ui.forms.widgets.Section;
+import org.eclipse.ui.views.properties.tabbed.ITabbedPropertyConstants;
 import org.wso2.developerstudio.eclipse.gmf.esb.CallTemplateParameter;
 import org.wso2.developerstudio.eclipse.gmf.esb.CloudConnectorOperation;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
@@ -1044,6 +1048,20 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
             } else if (!eefElementEditorReadOnlyState && !connectorParameters.isEnabled()) {
                 connectorParameters.setEnabled(true);
             }
+
+            //Adjust table size according to no of params
+            EObject dataObject = ((ReferencesTableSettings) settings).getSource();
+            EList<CallTemplateParameter> parameterList = ((CloudConnectorOperation) dataObject).getConnectorParameters();
+            int n0OfParams = parameterList.size();
+            int tableLength = 100 + (n0OfParams / 5) * 100;
+            Table connectorParamTable = this.connectorParameters.getTable();
+            FormData connectorParamFormData = new FormData();
+            connectorParamFormData.height = (tableLength >= 300) ? 300 : tableLength;
+            connectorParamFormData.top = new FormAttachment(6, ITabbedPropertyConstants.VSPACE + 4);
+            connectorParamFormData.left = new FormAttachment(0, ITabbedPropertyConstants.HSPACE);
+            connectorParamFormData.right = new FormAttachment(100, -ITabbedPropertyConstants.HSPACE);
+            connectorParamTable.setLayoutData(connectorParamFormData);
+            validate();
         }
     }
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
@@ -357,7 +357,7 @@ public class EEFPropertyViewUtil {
     }
 
     public static String spaceFormat(String str) {
-        int maxLength = 100;
+        int maxLength = 120;
         int tabSpace = (maxLength - str.length()) / 4;
         for (int i = 0; i < tabSpace; i++) {
             str = str.concat("\t");

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CallTemplateParameterItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/CallTemplateParameterItemProvider.java
@@ -183,7 +183,7 @@ public class CallTemplateParameterItemProvider extends EsbNodeItemProvider {
     @Override
     public String getText(Object object) {
         String parameterName = ((CallTemplateParameter) object).getParameterName();
-        String parameterNameLabel = WordUtils.abbreviate(parameterName, 40, 45, " ...");
+        String parameterNameLabel = WordUtils.abbreviate(parameterName, 100, 105, "...");
         String parameterType = ((CallTemplateParameter) object).getTemplateParameterType().toString();
         String parameterValue = ((CallTemplateParameter) object).getParameterValue();
         String parameterExpression = ((CallTemplateParameter) object).getParameterExpression().toString();
@@ -192,19 +192,16 @@ public class CallTemplateParameterItemProvider extends EsbNodeItemProvider {
             if (parameterValue != null) {
                 return parameterName == null || parameterName.length() == 0
                         ? getString("_UI_CallTemplateParameter_type")
-                        : getString("_UI_CallTemplateParameter_type") + "  -  "
-                                + EEFPropertyViewUtil.spaceFormat(parameterNameLabel)
+                        : EEFPropertyViewUtil.spaceFormat(parameterNameLabel)
                                 + EEFPropertyViewUtil.spaceFormat(parameterValue);
             } else {
                 return parameterName == null || parameterName.length() == 0
                         ? getString("_UI_CallTemplateParameter_type")
-                        : getString("_UI_CallTemplateParameter_type") + "  -  "
-                                + EEFPropertyViewUtil.spaceFormat(parameterNameLabel);
+                        : EEFPropertyViewUtil.spaceFormat(parameterNameLabel);
             }
         } else {
             return parameterName == null || parameterName.length() == 0 ? getString("_UI_CallTemplateParameter_type")
-                    : getString("_UI_CallTemplateParameter_type") + "  -  "
-                            + EEFPropertyViewUtil.spaceFormat(parameterNameLabel)
+                    : EEFPropertyViewUtil.spaceFormat(parameterNameLabel)
                             + EEFPropertyViewUtil.spaceFormat(parameterExpression);
         }
     }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/PropertyMediatorItemProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src/org/wso2/developerstudio/eclipse/gmf/esb/provider/PropertyMediatorItemProvider.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.edit.provider.ItemPropertyDescriptor;
 import org.eclipse.emf.edit.provider.ViewerNotification;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbFactory;
 import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
+import org.wso2.developerstudio.eclipse.gmf.esb.NamespacedProperty;
 import org.wso2.developerstudio.eclipse.gmf.esb.PropertyAction;
 import org.wso2.developerstudio.eclipse.gmf.esb.PropertyMediator;
 import org.wso2.developerstudio.eclipse.gmf.esb.PropertyName;
@@ -517,12 +518,19 @@ public class PropertyMediatorItemProvider extends MediatorItemProvider {
         int propertyTypeLength = 10;
         String newProperty = "newPropertyName";
         String emptySpace = StringUtils.rightPad("", spacing);
+        String propertyValue = "";
+        String propertyExpression = "";
 
         String propertyName = StringUtils.rightPad(((PropertyMediator) object).getPropertyName().getName(), maxLength);
         String propertyValueType = ((PropertyMediator) object).getValueType().toString();
-        String propertyValue = StringUtils.rightPad(((PropertyMediator) object).getValue(), maxLength);
-        String propertyExpression = StringUtils.rightPad(((PropertyMediator) object).getValueExpression().toString(),
-                maxLength);
+        String propertyTempValue = ((PropertyMediator) object).getValue();
+        if(propertyTempValue != null) {
+            propertyValue = StringUtils.rightPad(propertyTempValue, maxLength);
+        }
+        NamespacedProperty propertyTempExpression = ((PropertyMediator) object).getValueExpression();
+        if(propertyTempExpression != null) {
+            propertyExpression = StringUtils.rightPad(propertyTempExpression.toString(), maxLength);
+        }
 
         PropertyName labelValue = ((PropertyMediator) object).getPropertyName();
         String newPropertyName = ((PropertyMediator) object).getNewPropertyName();


### PR DESCRIPTION
## Purpose
1. Removed Call template parameter prefix in connector params.
2. Set param name character limit to 100.
3. Fixed null pointer when adding property without value or expression from source view.