### PR TITLE
Add no cache to urls

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/view/DeployedServicesView.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/view/DeployedServicesView.java
@@ -72,6 +72,7 @@ public class DeployedServicesView extends ViewPart {
     private static final String DEFAULT_PASSWORD = "admin";
     private static final String DEP_SERVICES_PROPERTIES_PATH = ResourcesPlugin.getWorkspace().getRoot().getLocation()
             .toOSString() + File.separator + ".metadata" + File.separator + "deployed_services.properties";
+    private static final String NO_CACHE = "&nocache=1";
 
     private Browser browser;
     private String accessToken;
@@ -115,7 +116,7 @@ public class DeployedServicesView extends ViewPart {
         String port = rootNode.get("portDetails", String.valueOf(FunctionServerConstants.EMBEDDED_SERVER_PORT));
         return "http://127.0.0.1:" + port + "/project/endpoints?" + API_DETAILS_GET_PARAM + "=" + apiList + "&"
                 + PROXY_DETAILS_GET_PARAM + "=" + proxyList + "&" + DATASERVICE_DETAILS_GET_PARAM + "="
-                + dataServiceList + "&port=" + port;
+                + dataServiceList + "&port=" + port + NO_CACHE;
     }
 
     @Override
@@ -124,7 +125,7 @@ public class DeployedServicesView extends ViewPart {
     }
 
     public void setURL(URL url) {
-        browser.setUrl(url.toString());
+        browser.setUrl(url.toString() + NO_CACHE);
     }
     
     private String generateAccessToken() throws IOException {

--- a/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ImportCloudConnectorWizardPage.java
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.project/src/org/wso2/developerstudio/eclipse/esb/project/ui/wizard/ImportCloudConnectorWizardPage.java
@@ -68,7 +68,7 @@ public class ImportCloudConnectorWizardPage extends WizardPage {
     private Button connectorStore;
     private Button fileSystem;
     private static final String LOAD_CONNECTORS_PAGE = "http://localhost:"
-            + FunctionServerConstants.EMBEDDED_SERVER_PORT + "/project/connectors/index.html";
+            + FunctionServerConstants.EMBEDDED_SERVER_PORT + "/project/connectors/index.html?nocache=1";
 
     private static IDeveloperStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
     private static ImportCloudConnectorWizardPage wizard;

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/swagger/EsbSwaggerEditor.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.diagram/src/org/wso2/developerstudio/eclipse/gmf/esb/diagram/swagger/EsbSwaggerEditor.java
@@ -91,7 +91,7 @@ public class EsbSwaggerEditor extends AbstractWebBasedEditor {
     public void createPartControl(Composite parent) {
         browser = createBrowser(parent);
         String port = getPortValueForJS();
-        browser.setUrl("http://127.0.0.1:" + port + "/swagger-editor" + "?port=" + getJettyPort());
+        browser.setUrl("http://127.0.0.1:" + port + "/swagger-editor" + "?port=" + getJettyPort() + "&nocache=1");
     }
 
     private Browser createBrowser(Composite parent) {

--- a/plugins/org.wso2.developerstudio.visualdatamapper/src/org/wso2/developerstudio/datamapper/views/RealtimeDatamapperView.java
+++ b/plugins/org.wso2.developerstudio.visualdatamapper/src/org/wso2/developerstudio/datamapper/views/RealtimeDatamapperView.java
@@ -46,13 +46,14 @@ import org.osgi.framework.Bundle;
 public class RealtimeDatamapperView extends ViewPart {
 
     public static final int EMBEDDED_SERVER_PORT = 7774;
+    private static final String NO_CACHE = "&nocache=1";
     private Browser browser;
 
     @Override
     public void createPartControl(Composite arg0) {
         browser = new Browser(arg0, SWT.NONE);
         String port = getPortValueForJS();
-        browser.setUrl("http://localhost:" + port + "/dataMapper?port=" + port);
+        browser.setUrl("http://localhost:" + port + "/dataMapper?port=" + port + NO_CACHE);
     }
 
     public void closeBrowser() {
@@ -65,12 +66,12 @@ public class RealtimeDatamapperView extends ViewPart {
     }
 
     public void setURL(URL url) {
-        browser.setUrl(url.toString());
+        browser.setUrl(url.toString() + NO_CACHE);
     }
 
     public void setURL() {
         String port = getPortValueForJS();
-        browser.setUrl("http://localhost:" + port + "/dataMapper?port=" + port);
+        browser.setUrl("http://localhost:" + port + "/dataMapper?port=" + port + NO_CACHE);
         browser.refresh();
     }
 
@@ -82,7 +83,7 @@ public class RealtimeDatamapperView extends ViewPart {
     public void setURL(String inputSchema, String outputSchema) {
         String port = getPortValueForJS();
         browser.setUrl("http://localhost:" + port + "/dataMapper?port=" + port + "&inputtype=" + inputSchema
-                + "&outputtype=" + outputSchema);
+                + "&outputtype=" + outputSchema + NO_CACHE);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Add `nocache=1` to urls to avoid loading views from previous versions of developer studio when old workspace are used.

##Affected views
1. Deployed Services
2. Import connector to Config module view
3. REST API Swagger Editor
4. Realtime Data Mapper Preview

Fix: https://github.com/wso2/devstudio-tooling-ei/issues/1234