### PR TITLE
Add connector UI support for table widgets

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/ConnectorParameterRenderer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/ConnectorParameterRenderer.java
@@ -17,6 +17,11 @@
  */
 package org.wso2.developerstudio.eclipse.gmf.esb.presentation;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import org.codehaus.jettison.json.JSONException;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
@@ -27,10 +32,12 @@ import org.eclipse.swt.custom.StyledText;
 import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
+
+import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.Text;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
-import org.eclipse.swt.widgets.Group;
-import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.forms.widgets.FormToolkit;
 import org.wso2.developerstudio.eclipse.gmf.esb.CallTemplateParameter;
 import org.wso2.developerstudio.eclipse.gmf.esb.CloudConnectorOperation;
@@ -44,10 +51,6 @@ import org.wso2.developerstudio.eclipse.gmf.esb.presentation.desc.parser.Connect
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.desc.parser.Element;
 import org.wso2.developerstudio.eclipse.logging.core.IDeveloperStudioLog;
 import org.wso2.developerstudio.eclipse.logging.core.Logger;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 public class ConnectorParameterRenderer extends PropertyParameterRenderer {
 
@@ -134,6 +137,8 @@ public class ConnectorParameterRenderer extends PropertyParameterRenderer {
             widgetProvider.createPasswordTextBoxFieldWithButton(widgetFactory, parent, value);
         } else if (AttributeValueType.SEARCHBOX.equals(value.getType())) {
             widgetProvider.createSearchBoxFieldWithButton(widgetFactory, parent, value);
+        } else if (AttributeValueType.KEYVALUETABLE.equals(value.getType())) {
+            widgetProvider.createKeyValueTable(widgetFactory, parent, value);
         }
     }
 
@@ -214,6 +219,14 @@ public class ConnectorParameterRenderer extends PropertyParameterRenderer {
                         Combo combo = (Combo) controlList.get(key);
                         combo.setText(value);
                         combo.setData(ctp);
+                    } else if (controlList.get(key) instanceof Table) {
+                        Table table = (Table) controlList.get(key);
+                        table.setData(ctp);
+                        try {
+                            widgetProvider.deserializeKeyValueTableJson(ctp.getParameterValue(), table);
+                        } catch (JSONException e) {
+                            log.error("Error parsing JSON string", e);
+                        }
                     }
                     Control expControl = controlList.get(key + EEFPropertyConstants.EXPRESSION_FIELD_SUFFIX);
                     if (expControl != null) {

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyConstants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyConstants.java
@@ -33,4 +33,7 @@ public class EEFPropertyConstants {
     public static String ENABLE_LEGACY_PROPERTY_VIEW_PROGRAM_ARG = "org.wso2.developerstudio.properties.legacy";
     public static String EXPRESSION_TEXT_BOX = "expressiontextbox";
     public static String VALUE_TEXT_BOX = "valuetextbox";
+    public static String JSON_COLUMN_WIDGET_DATA = "jsonColumn";
+    public static String CONTROL_LIST_WIDGET_DATA = "controlList";
+    public static String JSON_OBJECT_WIDGET_DATA = "JSONObject";
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/EEFPropertyViewUtil.java
@@ -72,6 +72,8 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
 import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
@@ -644,5 +646,21 @@ public class EEFPropertyViewUtil {
                 nsp.setPropertyValue(value);
             }
         });
+    }
+
+    /**
+     * Get column instance by name
+     * @param table table instance
+     * @param text column text
+     * @return TableColumn
+     */
+    public static TableColumn getColumnByName(Table table, String text) {
+        TableColumn column = null;
+        for(TableColumn tableColumn: table.getColumns()) {
+            if(text != null && text.equals(tableColumn.getText())) {
+                column = tableColumn;
+            }
+        }
+        return column;
     }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/AttributeValue.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/AttributeValue.java
@@ -31,6 +31,7 @@ public class AttributeValue extends Value {
     boolean required;
     String helpTip;
     List<String> allowedConnectionTypes;
+    List<KeyValueTableColumn> columns;
     String validation;
     String defaultType; //????
     //String default; ????
@@ -41,6 +42,7 @@ public class AttributeValue extends Value {
 
         comboValues = new ArrayList<>();
         allowedConnectionTypes = new ArrayList<>();
+        columns = new ArrayList<>();
     }
 
     public String getName() {
@@ -146,5 +148,17 @@ public class AttributeValue extends Value {
     public void setEnableCondition(EnableCondition enableCondition) {
 
         this.enableCondition = enableCondition;
+    }
+
+    public List<KeyValueTableColumn> getColumns() {
+        return columns;
+    }
+
+    public void setColumns(List<KeyValueTableColumn> columns) {
+        this.columns = columns;
+    }
+
+    public void addColumn(KeyValueTableColumn column) {
+        this.columns.add(column);
     }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/ConnectorDescriptorParser.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/ConnectorDescriptorParser.java
@@ -109,6 +109,25 @@ public class ConnectorDescriptorParser {
                     case DescriptorConstants.SEARCH_BOX:
                         value.setType(AttributeValueType.SEARCHBOX);
                         break;
+                    case DescriptorConstants.KEY_VALUE_TABLE:
+                        value.setType(AttributeValueType.KEYVALUETABLE);
+                        JSONArray columns = attrObj
+                                .getJSONArray(DescriptorConstants.COLUMNS);
+                        for (int k = 0; k < columns.length(); k++) {
+                            KeyValueTableColumn kvtc = new KeyValueTableColumn();
+                            JSONObject column = columns.getJSONObject(k);
+                            kvtc.setName(column.getString(DescriptorConstants.NAME));
+                            kvtc.setType(column.getString(DescriptorConstants.TYPE));
+                            if(kvtc.getType().equals(DescriptorConstants.COMBO_STRING)) {
+                                JSONArray allowedValues = attrObj
+                                        .getJSONArray(DescriptorConstants.ALLOWED_VALUES);
+                                for (int l = 0; l < allowedValues.length(); l++) {
+                                    kvtc.addAllowedValues(allowedValues.getString(l));
+                                }
+                            }
+                            value.addColumn(kvtc);
+                        }
+                        break;
                     default:
                         value.setType(AttributeValueType.STRING);
                         break;
@@ -176,6 +195,26 @@ public class ConnectorDescriptorParser {
                         break;
                     case DescriptorConstants.SEARCH_BOX:
                         value.setType(AttributeValueType.SEARCHBOX);
+                        break;
+                    case DescriptorConstants.KEY_VALUE_TABLE:
+                        value.setType(AttributeValueType.KEYVALUETABLE);
+                        JSONArray columns = attrObj
+                                .getJSONArray(DescriptorConstants.COLUMNS);
+                        for (int k = 0; k < columns.length(); k++) {
+                            KeyValueTableColumn kvtc = new KeyValueTableColumn();
+                            JSONObject column = columns.getJSONObject(k);
+                            kvtc.setName(column.getString(DescriptorConstants.NAME));
+                            kvtc.setType(column.getString(DescriptorConstants.TYPE));
+                            if(kvtc.getType().equals(DescriptorConstants.COMBO_STRING) &&
+                                    column.has(DescriptorConstants.ALLOWED_VALUES)) {
+                                JSONArray allowedValues = column
+                                        .getJSONArray(DescriptorConstants.ALLOWED_VALUES);
+                                for (int l = 0; l < allowedValues.length(); l++) {
+                                    kvtc.addAllowedValues(allowedValues.getString(l));
+                                }
+                            }
+                            value.addColumn(kvtc);
+                        }
                         break;
                     default:
                         value.setType(AttributeValueType.STRING);

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/DescriptorConstants.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/DescriptorConstants.java
@@ -48,6 +48,10 @@ public class DescriptorConstants {
     public static final String VALIDATION = "attributeGroup";
     public static final String ENABLE_CONDITION = "enableCondition";
     public static final String COMBO_VALUES = "comboValues";
+    public static final String COMBO_STRING = "combo";
+    public static final String TEXT_STRING = "text";
+    public static final String COLUMNS = "columns";
+    public static final String ALLOWED_VALUES = "allowedValues";
 
     // Supported Input Types
     public static final String STRING = "string";
@@ -58,7 +62,8 @@ public class DescriptorConstants {
     public static final String COMBO_OR_EXPRESSION = "comboOrExpression";
     public static final String PASSWORD_TEXT_OR_EXPRESSION = "passwordTextOrExpression";
     public static final String SEARCH_BOX = "searchBox";
-    
+    public static final String KEY_VALUE_TABLE = "keyValueTable";
+
     //Key related to the Connection attribute
     public static final String CONFIG_REF = "configRef";
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/KeyValueTableColumn.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/KeyValueTableColumn.java
@@ -1,0 +1,45 @@
+package org.wso2.developerstudio.eclipse.gmf.esb.presentation.desc.parser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class KeyValueTableColumn {
+
+    public String name;
+    public String type;
+    public List<String> allowedValues;
+
+    public KeyValueTableColumn() {
+        super();
+        this.allowedValues =  new ArrayList<String>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public List<String> getAllowedValues() {
+        return allowedValues;
+    }
+
+    public void setAllowedValues(List<String> allowedValues) {
+        this.allowedValues = allowedValues;
+    }
+
+    public void addAllowedValues(String allowedValue) {
+         this.allowedValues.add(allowedValue);
+    }
+
+}


### PR DESCRIPTION
## Purpose
This pr adds connector UI support for table widgets. 'keyValueTable' input type is introduced and if the type is keyvaluetable columns field is mandatory. It defines the columns of the table.
And if a column is combo allowedValues is mandatory. to define values in the combo.
Ex :- 
```
            {
                  "type": "attribute",
                  "value": {
                    "name": "cc",
                    "displayName": "CC",
                    "inputType": "keyValueTable",
                    "defaultValue": "",
                    "columns": [
                    	{
                 		 "name": "key",
                 		 "type": "text"
                 		},
                 		{
                 		 "name": "valuetype",
                 		 "type": "combo",
                 		 "allowedValues": [
			                "String",
			                "Boolean",
			                "Integer"
			              ]
                 		}
                    ],
                    "required": "false",
                    "helpTip": "The recipient addresses of 'CC' (carbon copy) type"
                  }
                }
```

