### PR TITLE
Default value implementation for text fields and combo boxes

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/components/CloudConnectorOperationPropertiesEditionComponent.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/components/CloudConnectorOperationPropertiesEditionComponent.java
@@ -58,6 +58,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.EsbPackage;
 
 import org.wso2.developerstudio.eclipse.gmf.esb.parts.CloudConnectorOperationPropertiesEditionPart;
 import org.wso2.developerstudio.eclipse.gmf.esb.parts.EsbViewsRepository;
+import org.wso2.developerstudio.eclipse.gmf.esb.parts.forms.CloudConnectorOperationPropertiesEditionPartForm;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.ConnectorSchemaHolder;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.EEFPropertyViewUtil;
 
@@ -157,18 +158,24 @@ public class CloudConnectorOperationPropertiesEditionComponent extends SinglePar
 				// Start of user code for additional businessfilters for connectorParameters
 				// End of user code
 			}
-			
-			
-			
-			
-			
-			
+
+
+
+
+
+
 			// init values for referenced views
-			
+
 			// init filters for referenced views
-			
+
 		}
 		setInitializing(false);
+
+		// Start of user code for additional businessfilters for connectorParameters
+		if (editingPart != null) {
+			((CloudConnectorOperationPropertiesEditionPartForm) editingPart).afterInitialization();
+		}
+		// End of user code
 	}
 
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
@@ -138,7 +138,7 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
     private boolean hasConnectorSchema;
     protected CLabel infoLabel;
     private static IDeveloperStudioLog log = Logger.getLog(EEFPropertyViewUtil.PLUGIN_ID);
-	private ConnectorParameterRenderer propertyRenderer;
+    private ConnectorParameterRenderer propertyRenderer;
     // End of user code
 
 	/**
@@ -444,8 +444,8 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
             CloudConnectorOperationImpl connectorObject = (CloudConnectorOperationImpl)propertiesEditionComponent.getEditingContext().getEObject();
             String schemaName = connectorObject.getConnectorName().split("connector")[0] + "-" + connectorObject.getOperationName();
             propertyRenderer = new ConnectorParameterRenderer(propertiesEditionComponent, this);
-			this.connectorParameters = new ReferenceGroup(getDescription(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters, null),
-					propertyRenderer, schemaName);
+            this.connectorParameters = new ReferenceGroup(getDescription(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters, null),
+                    propertyRenderer, schemaName);
             this.connectorParameters.createControls(parent, widgetFactory);
             connectorParameters.setID(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters);
             connectorParameters.setEEFType("eef::AdvancedTableComposition");

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/parts/forms/CloudConnectorOperationPropertiesEditionPartForm.java
@@ -138,6 +138,7 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
     private boolean hasConnectorSchema;
     protected CLabel infoLabel;
     private static IDeveloperStudioLog log = Logger.getLog(EEFPropertyViewUtil.PLUGIN_ID);
+	private ConnectorParameterRenderer propertyRenderer;
     // End of user code
 
 	/**
@@ -442,8 +443,9 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
 	    if(hasConnectorSchema) {
             CloudConnectorOperationImpl connectorObject = (CloudConnectorOperationImpl)propertiesEditionComponent.getEditingContext().getEObject();
             String schemaName = connectorObject.getConnectorName().split("connector")[0] + "-" + connectorObject.getOperationName();
-            this.connectorParameters = new ReferenceGroup(getDescription(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters, null),
-                    new ConnectorParameterRenderer(propertiesEditionComponent, this), schemaName);
+            propertyRenderer = new ConnectorParameterRenderer(propertiesEditionComponent, this);
+			this.connectorParameters = new ReferenceGroup(getDescription(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters, null),
+					propertyRenderer, schemaName);
             this.connectorParameters.createControls(parent, widgetFactory);
             connectorParameters.setID(EsbViewsRepository.CloudConnectorOperation.Properties.connectorParameters);
             connectorParameters.setEEFType("eef::AdvancedTableComposition");
@@ -1378,6 +1380,13 @@ public class CloudConnectorOperationPropertiesEditionPartForm extends SectionPro
         infoLabel.setText(bannerMessage);
         infoLabel.getParent().layout();
     }
+
+	public void afterInitialization(){
+		if (propertyRenderer != null) {
+			propertyRenderer.addDefaultValues();
+			propertyRenderer = null;
+		}
+	}
 	// End of user code
 
 

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/ConnectorParameterRenderer.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/ConnectorParameterRenderer.java
@@ -228,6 +228,34 @@ public class ConnectorParameterRenderer extends PropertyParameterRenderer {
         widgetProvider.checkRequired();
     }
 
+    public void addDefaultValues() {
+
+        for (Control control : controlList.values()) {
+
+            AttributeValue uiSchemaValue = (AttributeValue) control.getData(EEFPropertyConstants.UI_SCHEMA_OBJECT_KEY);
+            if (uiSchemaValue != null) {
+                String defaultValue = uiSchemaValue.getDefaultValue();
+
+                if (control instanceof Text) {
+                    Text text = (Text) control;
+                    if (uiSchemaValue.getRequired() && defaultValue != null && !defaultValue.isEmpty() &&
+                            text.getText().equals("")) {
+                        text.setText(defaultValue);
+                        text.notifyListeners(SWT.KeyUp, new Event());
+                    }
+
+                } else if (control instanceof Combo) {
+                    Combo combo = (Combo) control;
+                    if (defaultValue != null && !defaultValue.isEmpty() && combo.getText().equals("")) {
+                        combo.setText(defaultValue);
+                        combo.notifyListeners(SWT.Selection, new Event());
+                    }
+                }
+            }
+
+        }
+    }
+
     public void validate() {
         // Todo: Enable condition logic
     }


### PR DESCRIPTION
## Purpose
Implementation for default value field the component descriptor JSON.

## Samples
An element in the descriptor JSON can have a default value as bellow,
```json
{
  "type": "attribute",
  "value": {
    "name": "csvEmptyValues",
    "displayName": "Empty Values",
    "inputType": "comboOrExpression",
    "defaultValue": "Null",
    "required": "false",
    "comboValues": [
      "Null",
      "Empty"
    ]
  }
}
```
For text boxes, the default value would be applied only if the require field is true,

```json
{
  "type": "attribute",
  "value": {
    "name": "jsonKeys",
    "displayName": "JSON keys",
    "inputType": "stringOrExpression",
    "defaultValue": "default",
    "required": "true"
  }
}
```