### PR TITLE
Add not condition operator type

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/PropertiesWidgetProvider.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/PropertiesWidgetProvider.java
@@ -273,7 +273,7 @@ public class PropertiesWidgetProvider {
         } catch (URISyntaxException | IOException e1) {
             log.error("Couldn't fetch property field icon", e1);
         }
-
+        addToEnableConditionManager(jsonSchemaObject, jsonSchemaObject.getName());
         // Create Text box widget
         final Text valueTextBox = widgetFactory.createText(textBoxComposite, "", SWT.BORDER);
         valueTextBox.setData(FormToolkit.KEY_DRAW_BORDER, FormToolkit.TEXT_BORDER);
@@ -293,6 +293,7 @@ public class PropertiesWidgetProvider {
                     AttributeValue uiSchemaValue = (AttributeValue) ((Text) e.getSource())
                             .getData(EEFPropertyConstants.UI_SCHEMA_OBJECT_KEY);
                     updateModel(ctp, valueTextBox, uiSchemaValue);
+                    updateEnableConditionValidation(jsonSchemaObject.getName(), ctp.getParameterValue());
                 }
             }
         });

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/condition/manager/NotConditionOperation.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/condition/manager/NotConditionOperation.java
@@ -17,8 +17,23 @@
  */
 package org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager;
 
-public enum ConditionOperatorType {
-    OR,
-    AND,
-    NOT
+import java.util.List;
+import java.util.Map;
+
+public class NotConditionOperation extends ConditionOperation {
+
+    public NotConditionOperation(List<EnableCondition> arguments) {
+
+        super(arguments);
+    }
+
+    @Override
+    public boolean isValid(Map<String, String> componentsValueMap) {
+
+        if (!getArguments().isEmpty()) {
+            EnableCondition firstArgument = getArguments().get(0);
+            return !firstArgument.isValid(componentsValueMap);
+        }
+        return false;
+    }
 }

--- a/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/ConnectorDescriptorParser.java
+++ b/plugins/org.wso2.developerstudio.eclipse.gmf.esb.edit/src-gen/org/wso2/developerstudio/eclipse/gmf/esb/presentation/desc/parser/ConnectorDescriptorParser.java
@@ -24,6 +24,7 @@ import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.A
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.ConditionArgument;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.ConditionOperatorType;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.EnableCondition;
+import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.NotConditionOperation;
 import org.wso2.developerstudio.eclipse.gmf.esb.presentation.condition.manager.OrConditionOperation;
 
 import java.util.ArrayList;
@@ -249,10 +250,16 @@ public class ConnectorDescriptorParser {
                 for (int i = 1; i < jsonArray.length(); i++) {
                     arguments.add(parseConditionArgument(jsonArray.getJSONObject(i)));
                 }
-                if (operatorType == ConditionOperatorType.AND) {
-                    enableCondition = new AndConditionOperation(arguments);
-                } else {
-                    enableCondition = new OrConditionOperation(arguments);
+
+                switch (operatorType) {
+                    case AND:
+                        enableCondition = new AndConditionOperation(arguments);
+                        break;
+                    case NOT:
+                        enableCondition = new NotConditionOperation(arguments);
+                        break;
+                    default:
+                        enableCondition = new OrConditionOperation(arguments);
                 }
             } catch (IllegalArgumentException e) {
                 throw new RuntimeException("Invalid operation type");


### PR DESCRIPTION
## Purpose
Add `Not` condition operator to enable condition expressions. 


## Samples
`enableCondition` in property view descriptor JSON supports `NOT` operations,

```json
 "enableCondition": ["NOT", {"foo":"bar"}]
```