### PR TITLE
Change Proxy WSDL URL validator to allow localhost

### DIFF
--- a/plugins/org.wso2.developerstudio.eclipse.artifact.proxyservice/src/org/wso2/developerstudio/eclipse/artifact/proxyservice/model/ProxyServiceModel.java
+++ b/plugins/org.wso2.developerstudio.eclipse.artifact.proxyservice/src/org/wso2/developerstudio/eclipse/artifact/proxyservice/model/ProxyServiceModel.java
@@ -246,7 +246,7 @@ public class ProxyServiceModel extends ProjectDataModel {
             String url = (String) data;
             if (StringUtils.isNotBlank(url)) {
                 setProxyWSDLurl(url);
-                UrlValidator urlValidator = new UrlValidator();
+                UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
                 if (urlValidator.isValid(url)) {
                     addAvailableNames(url);
                 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Currently, URL validator does not accept localhost as a proper valid URL.

Resolves https://github.com/wso2/devstudio-tooling-ei/issues/1317