### PR TITLE
Revert "Update the build pom file to build with eclipse 2020"

### DIFF
--- a/features/org.wso2.developerstudio.eclipse.esb.dependencies.feature/feature.xml
+++ b/features/org.wso2.developerstudio.eclipse.esb.dependencies.feature/feature.xml
@@ -21,28 +21,28 @@
          id="org.eclipse.emf.validation"
          download-size="0"
          install-size="0"
-         version="1.8.0.201812070911"
+         version="1.8.0.201706061352"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.emf.query"
          download-size="0"
          install-size="0"
-         version="1.7.0.201805030653"
+         version="1.7.0.201706061326"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.emf.transaction"
          download-size="0"
          install-size="0"
-         version="1.9.1.201805140824"
+         version="1.9.0.201706061339"
          unpack="false"/>
 
    <plugin
          id="org.eclipse.emf.workspace"
          download-size="0"
          install-size="0"
-         version="1.5.1.201805140824"
+         version="1.5.1.201706061339"
          unpack="false"/>
 
 <plugin
@@ -133,207 +133,207 @@
          id="org.eclipse.gmf.runtime.common.core"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui"
          download-size="0"
          install-size="0"
-         version="1.8.1.202004160913"
+         version="1.8.1.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.action"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.action.ide"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.printing"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.services.action"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.services.properties"
          download-size="0"
          install-size="0"
-         version="1.9.0.202004160913"
+         version="1.9.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.services"
          download-size="0"
          install-size="0"
-         version="1.9.0.202004160913"
+         version="1.9.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.core"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.actions"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.printing.render"
          download-size="0"
          install-size="0"
-         version="1.8.0.202004160913"
+         version="1.8.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.printing"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.properties"
          download-size="0"
          install-size="0"
-         version="1.8.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.providers.ide"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.providers"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.render"
          download-size="0"
          install-size="0"
-         version="1.7.1.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.resources.editor.ide"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui.resources.editor"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.diagram.ui"
          download-size="0"
          install-size="0"
-         version="1.9.0.202004160913"
+         version="1.8.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.draw2d.ui.render.awt"
          download-size="0"
          install-size="0"
-         version="1.8.0.202004160913"
+         version="1.8.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.draw2d.ui.render"
          download-size="0"
          install-size="0"
-         version="1.7.1.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.draw2d.ui"
          download-size="0"
          install-size="0"
-         version="1.9.1.202004160913"
+         version="1.9.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.emf.commands.core"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
          
 <plugin
          id="org.eclipse.gmf.runtime.emf.core"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.emf.type.core"
          download-size="0"
          install-size="0"
-         version="1.9.0.202004160913"
+         version="1.9.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.emf.ui.properties"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.emf.ui"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.gef.ui"
          download-size="0"
          install-size="0"
-         version="1.7.1.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.notation"
          download-size="0"
          install-size="0"
-         version="1.10.0.202004160913"
+         version="1.8.0.201706061354"
          unpack="false"/>
 <plugin
          id="org.eclipse.ocl.ecore"
          download-size="0"
          install-size="0"
-         version="3.15.0.v20200608-1555"
+         version="3.6.200.v20170522-1736"
          unpack="false"/>
 <plugin
          id="org.eclipse.ocl"
          download-size="0"
          install-size="0"
-         version="3.15.0.v20200608-1555"
+         version="3.6.200.v20170522-1736"
          unpack="false"/>
 <plugin
          id="org.eclipse.ocl.common"
          download-size="0"
          install-size="0"
-         version="1.8.400.v20200608-1555"
+         version="1.4.200.v20160613-1518"
          unpack="false"/>
 
 <plugin
          id="org.eclipse.gmf.runtime.common.ui.printing.win32"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.eclipse.gmf.runtime.emf.clipboard.core"
          download-size="0"
          install-size="0"
-         version="1.7.0.202004160913"
+         version="1.7.0.201706061437"
          unpack="false"/>
 <plugin
          id="org.junit4"
@@ -342,10 +342,10 @@
          version="4.8.1.v20120523-1257-wso2v1"
          unpack="false"/>
 <plugin
-         id="org.eclipse.papyrus.infra.core.architecture"
+         id="org.eclipse.papyrus.infra.core.architecture.edit"
          download-size="0"
          install-size="0"
-         version="2.1.100.202006100749"
+         version="0.0.0"
          unpack="false"/>
 
 </feature>

--- a/plugins/org.wso2.developerstudio.eclipse.esb.libraries/pom.xml
+++ b/plugins/org.wso2.developerstudio.eclipse.esb.libraries/pom.xml
@@ -82,12 +82,27 @@
                 <environment>
                   <os>linux</os>
                   <ws>gtk</ws>
+                  <arch>x86</arch>
+                </environment>
+                <environment>
+                  <os>linux</os>
+                  <ws>gtk</ws>
                   <arch>x86_64</arch>
                 </environment>
                 <environment>
                   <os>win32</os>
                   <ws>win32</ws>
+                  <arch>x86</arch>
+                </environment>
+                <environment>
+                  <os>win32</os>
+                  <ws>win32</ws>
                   <arch>x86_64</arch>
+                </environment>
+                <environment>
+                  <os>macosx</os>
+                  <ws>cocoa</ws>
+                  <arch>x86</arch>
                 </environment>
                 <environment>
                   <os>macosx</os>
@@ -104,12 +119,27 @@
             <environment>
               <os>linux</os>
               <ws>gtk</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>linux</os>
+              <ws>gtk</ws>
               <arch>x86_64</arch>
             </environment>
             <environment>
               <os>win32</os>
               <ws>win32</ws>
+              <arch>x86</arch>
+            </environment>
+            <environment>
+              <os>win32</os>
+              <ws>win32</ws>
               <arch>x86_64</arch>
+            </environment>
+            <environment>
+              <os>macosx</os>
+              <ws>cocoa</ws>
+              <arch>x86</arch>
             </environment>
             <environment>
               <os>macosx</os>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
             <id>Eclipse-p2-repo</id>
-            <url>http://download.eclipse.org/releases/2020-06/</url>
+            <url>http://download.eclipse.org/releases/oxygen/</url>
             <layout>p2</layout>
         </repository>
         <repository>
@@ -261,12 +261,27 @@
                         <environment>
                             <os>linux</os>
                             <ws>gtk</ws>
+                            <arch>x86</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
                             <arch>x86_64</arch>
                         </environment>
                         <environment>
                             <os>win32</os>
                             <ws>win32</ws>
+                            <arch>x86</arch>
+                        </environment>
+                        <environment>
+                            <os>win32</os>
+                            <ws>win32</ws>
                             <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>x86</arch>
                         </environment>
                         <environment>
                             <os>macosx</os>


### PR DESCRIPTION
Reverts wso2/devstudio-tooling-esb#1379
Moved eclipse migration-related commit to a new branch "eclipse-2020-migration"

